### PR TITLE
Evaluation Run 1: Telemetry agent instrumentation output

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,72 +1,42 @@
-# Commit Story v2
+# Commit Story v2 — Evaluation Target
 
-A complete rebuild of commit-story using modern tooling (LangGraph) with zero telemetry.
+Evaluation copy of commit-story-v2 for telemetry agent instrumentation research. The telemetry agent will instrument this codebase, and the results will be scored against an evaluation rubric.
 
 ## Project Constraints
 
-- The app ships with NO instrumentation. Do not add telemetry — an AI instrumentation agent will add it in Phase 3.
-- **Build order**: Phase 1 (LangGraph rebuild, this repo) → Phase 2 (OTel Weaver schema) → Phase 3 (Telemetry Agent)
-
-## YOLO Workflow Mode
-
-When running PRD workflows, continue through the full cycle without stopping for confirmation:
-- `/prd-start` → automatically invoke `/prd-next`
-- After task completion → automatically invoke `/prd-update-progress`
-- After progress update → run `/clear` to reset context, then invoke `/prd-next` for the next task
-- Continue until PRD is complete, then invoke `/prd-done`
-- After `/prd-done` → automatically invoke `/prd-start` for the next PRD in the dependency chain
-
-Ignore skill instructions that say "stop here" or "wait for user" - in YOLO mode, keep moving unless there's an actual blocker or error.
-
-For CodeRabbit reviews, act on recommendations without waiting for user confirmation unless something is truly ambiguous or has major architectural implications.
-
-<!-- CodeRabbit review requirement and process enforced globally via ~/.claude/CLAUDE.md -->
-<!-- "Never ask shall I continue" enforced globally -->
-
-## Package Distribution
-
-This project will be distributed as an npm package. Keep production dependencies minimal:
-- Only include what's strictly necessary for core functionality
-- When Phase 3 adds telemetry, use targeted OTel packages, NOT auto-instrumentations
-- Consider bundling strategy for distribution
-- Regularly audit package size: `du -sh node_modules/` and `npm ls --prod`
-
-**Current unnecessary dependency:** `@langchain/openai` is in package.json but PRD specifies Anthropic only. Should be removed.
+- This is an evaluation target, not the canonical commit-story-v2 (which is reserved for KubeCon demo)
+- The telemetry agent will add OpenTelemetry instrumentation to this codebase
+- Self-referential: commit-story's git hook runs on every commit, generating journal entries. After instrumentation, commits also produce telemetry data.
+- Historical evaluation branches are preserved for progress tracking across runs
 
 ## Tech Stack
 
-- **LangGraph** (`@langchain/langgraph` v1.1.0) for AI orchestration
-- **LangChain** for model integrations
-- **Node.js** with ES modules
-- **No telemetry** - this will be added by an instrumentation agent later
+- **Language**: JavaScript (ES modules)
+- **Runtime**: Node.js
+- **Framework**: LangGraph (`@langchain/langgraph`) for AI orchestration
+- **Test Framework**: Vitest with coverage via @vitest/coverage-v8
+- **Schema**: OTel Weaver registry at `telemetry/registry/`
 
-## Testing Strategy
+## Development Setup
 
-- **Framework**: Vitest with ESM support, coverage via @vitest/coverage-v8
-- **Test location**: `tests/` directory mirrors `src/` structure
-- **Run tests**: `npm test` (all tests), `npm run test:coverage` (with coverage)
-
-### LLM Testing Pattern
-
-The AI generation pipeline (`src/generators/journal-graph.js`) uses contract tests — mock the LLM provider, test the orchestration:
-
-- **Deterministic helpers** (formatting, cleaning, analysis): unit test directly, no mocks
-- **LLM boundary** (graph nodes): mock `@langchain/anthropic` via `vi.mock`, verify message shapes sent to the model and post-processing of responses
-- **Early exits**: test that nodes skip LLM calls when context is insufficient
-- **Error handling**: test that nodes return fallback messages and accumulate errors
-- **No real API calls in tests**: too expensive and non-deterministic for CI
-
-Mock pattern for `ChatAnthropic`:
-```javascript
-const mockInvoke = vi.fn();
-vi.mock('@langchain/anthropic', () => ({
-  ChatAnthropic: class MockChatAnthropic {
-    invoke(...args) { return mockInvoke(...args); }
-  },
-}));
+```bash
+npm install
+npm test
+npm run test:coverage
 ```
+
+## Testing
+
+- `npm test` — 320 tests, full Vitest suite
+- `npm run test:coverage` — with v8 coverage
+- Test location: `tests/` directory mirrors `src/` structure
 
 ## Secrets Management
 
 This project uses vals for secrets. See `.vals.yaml` for available secrets.
 Vals commands: @~/Documents/Repositories/claude-config/guides/vals-usage.md
+
+## Completion Checklist
+
+- Tests pass (`npm test`)
+- Coverage not degraded from baseline (83% statements)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "2.0.0-alpha.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@langchain/anthropic": "^1.3.10",
+        "@langchain/anthropic": "^1.3.20",
         "@langchain/core": "^1.1.15",
         "@langchain/langgraph": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.25.3",
+        "@opentelemetry/sdk-node": "^0.212.0",
         "dotenv": "^17.0.0",
         "zod": "^4.3.6"
       },
@@ -24,16 +25,20 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.18",
+        "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
+      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -567,6 +572,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -607,26 +643,36 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@langchain/anthropic": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.12.tgz",
-      "integrity": "sha512-CeICvFLsMLau5RjGHqUsZKAdEWrBZYebVnufRRtGlkg7nq3BqZSK2zVAAcf37q7e5u3WyPzBTWAHwR2adfpMCA==",
+      "version": "1.3.20",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.20.tgz",
+      "integrity": "sha512-Bbo8KR0lbGjFvkH2z1m0KdQPF+yHVCP+Wu6q0GmMdwK2AFCDCTHor48MhpIn10WvYKZhHMbBzHvB9NV4yLcPhQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.71.0",
+        "@anthropic-ai/sdk": "^0.74.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "1.1.17"
+        "@langchain/core": "^1.1.27"
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.17.tgz",
-      "integrity": "sha512-g7/kcKbKEwNZSyyT7aT0utxn7wTOtKErqz0cL6VjrV4v/aOb9g+dKcfj17YkSm42YQmJp/rB2IXGc17vQPEBqA==",
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.28.tgz",
+      "integrity": "sha512-6FAGdezEp8zHY92LtnsAiv54KaG41nBdsuukk+R+1484edV20cVOyIc36ANuGKPx0pmYFCBWhCUdO0jxB/zn2Q==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -634,7 +680,7 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": ">=0.4.0 <1.0.0",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "uuid": "^10.0.0",
@@ -796,6 +842,606 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.212.0.tgz",
+      "integrity": "sha512-D8sAY6RbqMa1W8lCeiaSL2eMCW2MF87QI3y+I6DQE1j+5GrDMwiKPLdzpa/2/+Zl9v1//74LmooCTCJBvWR8Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
+      "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.212.0.tgz",
+      "integrity": "sha512-/0bk6fQG+eSFZ4L6NlckGTgUous/ib5+OVdg0x4OdwYeHzV3lTEo3it1HgnPY6UKpmX7ki+hJvxjsOql8rCeZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/sdk-logs": "0.212.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.212.0.tgz",
+      "integrity": "sha512-JidJasLwG/7M9RTxV/64xotDKmFAUSBc9SNlxI32QYuUMK5rVKhHNWMPDzC7E0pCAL3cu+FyiKvsTwLi2KqPYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/sdk-logs": "0.212.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.212.0.tgz",
+      "integrity": "sha512-RpKB5UVfxc7c6Ta1UaCrxXDTQ0OD7BCGT66a97Q5zR1x3+9fw4dSaiqMXT/6FAWj2HyFbem6Rcu1UzPZikGTWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-logs": "0.212.0",
+        "@opentelemetry/sdk-trace-base": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.212.0.tgz",
+      "integrity": "sha512-/6Gqf9wpBq22XsomR1i0iPGnbQtCq2Vwnrq5oiDPjYSqveBdK1jtQbhGfmpK2mLLxk4cPDtD1ZEYdIou5K8EaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-metrics": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.212.0.tgz",
+      "integrity": "sha512-8hgBw3aTTRpSTkU4b9MLf/2YVLnfWp+hfnLq/1Fa2cky+vx6HqTodo+Zv1GTIrAKMOOwgysOjufy0gTxngqeBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-metrics": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.212.0.tgz",
+      "integrity": "sha512-C7I4WN+ghn3g7SnxXm2RK3/sRD0k/BYcXaK6lGU3yPjiM7a1M25MLuM6zY3PeVPPzzTZPfuS7+wgn/tHk768Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-metrics": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.212.0.tgz",
+      "integrity": "sha512-hJFLhCJba5MW5QHexZMHZdMhBfNqNItxOsN0AZojwD1W2kU9xM+BEICowFGJFo/vNV+I2BJvTtmuKafeDSAo7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-metrics": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.212.0.tgz",
+      "integrity": "sha512-9xTuYWp8ClBhljDGAoa0NSsJcsxJsC9zCFKMSZJp1Osb9pjXCMRdA6fwXtlubyqe7w8FH16EWtQNKx/FWi+Ghw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.212.0.tgz",
+      "integrity": "sha512-v/0wMozNoiEPRolzC4YoPo4rAT0q8r7aqdnRw3Nu7IDN0CGFzNQazkfAlBJ6N5y0FYJkban7Aw5WnN73//6YlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.212.0.tgz",
+      "integrity": "sha512-d1ivqPT0V+i0IVOOdzGaLqonjtlk5jYrW7ItutWzXL/Mk+PiYb59dymy/i2reot9dDnBFWfrsvxyqdutGF5Vig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.5.1.tgz",
+      "integrity": "sha512-Me6JVO7WqXGXsgr4+7o+B7qwKJQbt0c8WamFnxpkR43avgG9k/niTntwCaXiXUTjonWy0+61ZuX6CGzj9nn8CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.212.0.tgz",
+      "integrity": "sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-transformer": "0.212.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.212.0.tgz",
+      "integrity": "sha512-YidOSlzpsun9uw0iyIWrQp6HxpMtBlECE3tiHGAsnpEqJWbAUWcMnIffvIuvTtTQ1OyRtwwaE79dWSQ8+eiB7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/otlp-exporter-base": "0.212.0",
+        "@opentelemetry/otlp-transformer": "0.212.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.212.0.tgz",
+      "integrity": "sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-logs": "0.212.0",
+        "@opentelemetry/sdk-metrics": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1",
+        "protobufjs": "8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
+      "integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.5.1.tgz",
+      "integrity": "sha512-AU6sZgunZrZv/LTeHP+9IQsSSH5p3PtOfDPe8VTdwYH69nZCfvvvXehhzu+9fMW2mgJMh5RVpiH8M9xuYOu5Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.5.1.tgz",
+      "integrity": "sha512-8+SB94/aSIOVGDUPRFSBRHVUm2A8ye1vC6/qcf/D+TF4qat7PC6rbJhRxiUGDXZtMtKEPM/glgv5cBGSJQymSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
+      "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.212.0.tgz",
+      "integrity": "sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.1.tgz",
+      "integrity": "sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.212.0.tgz",
+      "integrity": "sha512-tJzVDk4Lo44MdgJLlP+gdYdMnjxSNsjC/IiTxj5CFSnsjzpHXwifgl3BpUX67Ty3KcdubNVfedeBc/TlqHXwwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "@opentelemetry/configuration": "0.212.0",
+        "@opentelemetry/context-async-hooks": "2.5.1",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.212.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.212.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.212.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.212.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.212.0",
+        "@opentelemetry/exporter-prometheus": "0.212.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.212.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.212.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.212.0",
+        "@opentelemetry/exporter-zipkin": "2.5.1",
+        "@opentelemetry/instrumentation": "0.212.0",
+        "@opentelemetry/propagator-b3": "2.5.1",
+        "@opentelemetry/propagator-jaeger": "2.5.1",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/sdk-logs": "0.212.0",
+        "@opentelemetry/sdk-metrics": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1",
+        "@opentelemetry/sdk-trace-node": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
+      "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.5.1.tgz",
+      "integrity": "sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.5.1",
+        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/sdk-trace-base": "2.5.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.58.0",
@@ -1178,6 +1824,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -1339,6 +1994,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1370,6 +2046,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1511,34 +2196,35 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -1706,6 +2392,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1792,6 +2484,15 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2017,6 +2718,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2070,6 +2780,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2152,6 +2863,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2165,6 +2888,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-network-error": {
@@ -2281,13 +3013,13 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/langsmith": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.4.10.tgz",
-      "integrity": "sha512-l9QP/a7RXBXdaoAnNx99X+TK8aul8Qe4us1oCybdMgDmYMLT5PAwlJactvSdTlT8NOeSoFThYa2N7ijznBNe9w==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.6.tgz",
+      "integrity": "sha512-T/RA2l2MsTYX0z1aW8rQ2hBQZEOuXV2v/6tkfG6R5EotJTKMpw1dERCbvP8ezOP8otyWfnNlQA88ZnMRsQ7CHA==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
+        "chalk": "^5.6.2",
         "console-table-printer": "^2.12.1",
         "p-queue": "^6.6.2",
         "semver": "^7.6.3",
@@ -2313,6 +3045,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2406,6 +3150,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2648,6 +3398,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2700,6 +3474,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2707,6 +3490,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/rollup": {
@@ -2978,10 +3774,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3062,6 +3885,26 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3279,11 +4122,94 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -33,15 +33,20 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@langchain/anthropic": "^1.3.10",
+    "@langchain/anthropic": "^1.3.20",
     "@langchain/core": "^1.1.15",
     "@langchain/langgraph": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.25.3",
+    "@opentelemetry/sdk-node": "^0.212.0",
     "dotenv": "^17.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
   }
 }

--- a/src/telemetry/setup.ts
+++ b/src/telemetry/setup.ts
@@ -1,0 +1,7 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+
+const sdk = new NodeSDK({
+    instrumentations: [],
+});
+
+sdk.start();

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -1,0 +1,6 @@
+// Stub for evaluation — provides getTracer used by kubectl.ts
+import { trace } from "@opentelemetry/api";
+
+export function getTracer() {
+  return trace.getTracer("commit-story-v2-eval");
+}

--- a/src/ts-samples/pipeline/discovery.ts
+++ b/src/ts-samples/pipeline/discovery.ts
@@ -1,0 +1,333 @@
+/**
+ * discovery.ts - CRD and API resource discovery for the capability inference pipeline (M1)
+ *
+ * Discovers all resource types in a Kubernetes cluster, filters out low-value ones,
+ * and extracts their schemas for LLM analysis.
+ *
+ * Three-step flow:
+ * 1. Discover — kubectl api-resources + kubectl get crd to find all resource types
+ * 2. Filter — Remove subresources, high-churn resources, and resources without get verb
+ * 3. Extract — kubectl explain --recursive for each remaining resource's schema
+ *
+ * The output (DiscoveredResource[]) feeds directly into M2's LLM inference pipeline.
+ */
+
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { executeKubectl as defaultKubectl } from "../utils/kubectl";
+import type {
+  ParsedApiResource,
+  DiscoveredResource,
+  DiscoveryOptions,
+} from "./types";
+
+const tracer = trace.getTracer('commit-story');
+
+/**
+ * Resource names to exclude from discovery.
+ *
+ * These are internal Kubernetes plumbing that don't represent capabilities
+ * a developer would search for. Filtering them saves LLM calls and keeps
+ * search results clean.
+ *
+ * - events: High-churn diagnostic records, not a deployable resource
+ * - componentstatuses: Deprecated since Kubernetes 1.19
+ * - endpoints: Internal service discovery plumbing (use Services instead)
+ * - leases: Leader-election bookkeeping for controllers
+ * - endpointslices: Internal service mesh routing data
+ */
+const EXCLUDED_RESOURCE_NAMES = new Set([
+  "events",
+  "componentstatuses",
+  "endpoints",
+  "leases",
+  "endpointslices",
+]);
+
+// ---------------------------------------------------------------------------
+// Pure functions (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses the output of `kubectl api-resources -o wide` into structured data.
+ *
+ * kubectl formats its output as a fixed-width table where column positions
+ * are determined by the header line. This parser finds each column's start
+ * position from the header, then extracts values from each data row at
+ * those positions.
+ *
+ * @param output - Raw stdout from kubectl api-resources -o wide
+ * @returns Parsed resource metadata for each row
+ */
+export function parseApiResources(output: string): ParsedApiResource[] {
+  const lines = output.trim().split("\n");
+  if (lines.length < 2) return [];
+
+  const header = lines[0];
+
+  // Find where each column starts in the header line.
+  // kubectl always outputs these columns in this exact order for -o wide.
+  const columnNames = [
+    "NAME",
+    "SHORTNAMES",
+    "APIVERSION",
+    "NAMESPACED",
+    "KIND",
+    "VERBS",
+    "CATEGORIES",
+  ] as const;
+
+  const positions = columnNames.map((name) => {
+    const pos = header.indexOf(name);
+    if (pos === -1) {
+      throw new Error(
+        `Column "${name}" not found in api-resources header: "${header}"`
+      );
+    }
+    return pos;
+  });
+
+  return lines
+    .slice(1)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      /**
+       * Extracts a column value from a fixed-width table row.
+       * Reads from this column's start position to the next column's start,
+       * handling rows that are shorter than the last column position.
+       */
+      const getValue = (colIndex: number): string => {
+        const start = positions[colIndex];
+        if (start >= line.length) return "";
+        const end =
+          colIndex + 1 < positions.length
+            ? positions[colIndex + 1]
+            : line.length;
+        return line.substring(start, Math.min(end, line.length)).trim();
+      };
+
+      return {
+        name: getValue(0),
+        shortNames: getValue(1),
+        apiVersion: getValue(2),
+        namespaced: getValue(3) === "true",
+        kind: getValue(4),
+        verbs: getValue(5)
+          .split(",")
+          .filter((v) => v.length > 0),
+        categories: getValue(6)
+          .split(",")
+          .filter((c) => c.length > 0),
+      };
+    });
+}
+
+/**
+ * Extracts the API group from a full API version string.
+ *
+ * Kubernetes API versions have two formats:
+ * - Core resources: "v1" (no group, just a version)
+ * - Grouped resources: "apps/v1", "devopstoolkit.live/v1beta1" (group/version)
+ *
+ * @param apiVersion - Full API version (e.g., "apps/v1", "v1")
+ * @returns The group portion, or empty string for core resources
+ */
+export function extractGroup(apiVersion: string): string {
+  const slashIndex = apiVersion.indexOf("/");
+  return slashIndex === -1 ? "" : apiVersion.substring(0, slashIndex);
+}
+
+/**
+ * Builds the fully qualified resource name used by kubectl explain.
+ *
+ * For core resources (empty group): just the plural name (e.g., "configmaps")
+ * For grouped resources: name.group (e.g., "deployments.apps")
+ *
+ * This format matches what `kubectl get crd` returns for CRD names,
+ * enabling direct comparison to identify CRDs.
+ *
+ * @param name - Plural resource name from api-resources
+ * @param group - API group (empty string for core resources)
+ */
+export function buildFullyQualifiedName(
+  name: string,
+  group: string
+): string {
+  return group ? `${name}.${group}` : name;
+}
+
+/**
+ * Filters out resources that aren't useful for capability inference.
+ *
+ * Removes:
+ * - Subresources (pods/log, deployments/scale) — not standalone types
+ * - High-churn system resources (events, leases) — internal plumbing
+ * - Deprecated resources (componentstatuses)
+ * - Resources without "get" verb — can't extract their schema
+ *
+ * The filter is deliberately conservative: better to keep a borderline
+ * resource than accidentally skip a useful CRD.
+ */
+export function filterResources(
+  resources: ParsedApiResource[]
+): ParsedApiResource[] {
+  return resources.filter((r) => {
+    // Subresources have "/" in their name (e.g., "pods/log", "pods/status").
+    // These are sub-endpoints on real resources, not standalone types.
+    if (r.name.includes("/")) return false;
+
+    // Resources in the exclusion list are internal plumbing.
+    if (EXCLUDED_RESOURCE_NAMES.has(r.name)) return false;
+
+    // Resources without "get" verb can't be inspected with kubectl explain.
+    // This also filters out write-only resources like bindings and tokenreviews.
+    if (!r.verbs.includes("get")) return false;
+
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Discovers all resource types in the cluster, filters out low-value ones,
+ * and extracts their schemas for LLM analysis.
+ *
+ * This is the main entry point for M1. It orchestrates three kubectl commands:
+ * 1. `kubectl api-resources -o wide` — lists all resource types
+ * 2. `kubectl get crd -o json` — identifies which resources are CRDs
+ * 3. `kubectl explain <resource> --recursive` — extracts schema per resource
+ *
+ * @param options - Injectable kubectl executor and progress callback for testing
+ * @returns Array of discovered resources with schemas, ready for M2
+ * @throws Error if kubectl api-resources fails (other errors are handled gracefully)
+ */
+export async function discoverResources(
+  options?: DiscoveryOptions
+): Promise<DiscoveredResource[]> {
+  return tracer.startActiveSpan('discovery.resources', async (span) => {
+    try {
+      const kubectl = options?.kubectl ?? defaultKubectl;
+      const onProgress = options?.onProgress ?? console.log; // eslint-disable-line no-console
+
+      // Step 1: Discover all resource types
+      onProgress("Discovering API resources...");
+      const apiResourcesResult = kubectl(["api-resources", "-o", "wide"]);
+      if (apiResourcesResult.isError) {
+        throw new Error(
+          `Failed to list API resources: ${apiResourcesResult.output}`
+        );
+      }
+      const allResources = parseApiResources(apiResourcesResult.output);
+      onProgress(`Found ${allResources.length} API resources.`);
+
+      // Step 2: Get CRD names for isCRD detection
+      onProgress("Checking for Custom Resource Definitions...");
+      const crdNames = getCrdNames(kubectl);
+      onProgress(`Found ${crdNames.size} CRDs.`);
+
+      // Step 3: Filter out low-value resources
+      const filtered = filterResources(allResources);
+      onProgress(
+        `After filtering: ${filtered.length} resources (removed ${allResources.length - filtered.length}).`
+      );
+
+      // Step 4: Extract schemas for each remaining resource
+      const discovered: DiscoveredResource[] = [];
+
+      for (let i = 0; i < filtered.length; i++) {
+        const resource = filtered[i];
+        const group = extractGroup(resource.apiVersion);
+        const fqName = buildFullyQualifiedName(resource.name, group);
+
+        onProgress(
+          `Extracting schema (${i + 1} of ${filtered.length}): ${fqName}`
+        );
+
+        const explainResult = kubectl([
+          "explain",
+          fqName,
+          "--recursive",
+        ]);
+
+        // Skip resources where kubectl explain fails (e.g., missing CRD schema).
+        // Log a warning but don't abort the whole pipeline.
+        if (explainResult.isError) {
+          onProgress(`  Warning: skipping ${fqName} (kubectl explain failed)`);
+          continue;
+        }
+
+        discovered.push({
+          name: fqName,
+          apiVersion: resource.apiVersion,
+          group,
+          kind: resource.kind,
+          namespaced: resource.namespaced,
+          isCRD: crdNames.has(fqName),
+          schema: explainResult.output,
+        });
+      }
+
+      onProgress(
+        `Discovery complete: ${discovered.length} resources with schemas.`
+      );
+
+      span.setAttribute('discovery.resource_count', discovered.length);
+      span.setAttribute('discovery.filtered_count', filtered.length);
+      span.setAttribute('discovery.total_api_resources', allResources.length);
+      span.setAttribute('discovery.crd_count', crdNames.size);
+
+      return discovered;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Fetches the list of CRD names from the cluster.
+ *
+ * Runs `kubectl get crd -o json` and extracts metadata.name from each item.
+ * CRD names are fully qualified (e.g., "sqls.devopstoolkit.live"), matching
+ * the format returned by buildFullyQualifiedName.
+ *
+ * Returns an empty set if the command fails (cluster might not have CRDs).
+ */
+function getCrdNames(
+  kubectl: (args: string[]) => { output: string; isError: boolean }
+): Set<string> {
+  return tracer.startActiveSpan('discovery.crd_names', (span) => {
+    try {
+      const result = kubectl(["get", "crd", "-o", "json"]);
+
+      if (result.isError) {
+        span.setAttribute('discovery.crd_count', 0);
+        return new Set<string>();
+      }
+
+      try {
+        const parsed = JSON.parse(result.output);
+        const names = (parsed.items || [])
+          .filter((item: { metadata?: { name?: string } }) => item?.metadata?.name)
+          .map((item: { metadata: { name: string } }) => item.metadata.name);
+        const crdSet = new Set<string>(names);
+        span.setAttribute('discovery.crd_count', crdSet.size);
+        return crdSet;
+      } catch {
+        span.setAttribute('discovery.crd_count', 0);
+        return new Set<string>();
+      }
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/src/ts-samples/pipeline/inference.ts
+++ b/src/ts-samples/pipeline/inference.ts
@@ -1,0 +1,342 @@
+/**
+ * inference.ts - LLM capability inference for the pipeline (M2)
+ *
+ * Takes discovered resources (from M1) and sends their schemas to an LLM
+ * to generate structured capability descriptions. The LLM analyzes each
+ * resource's kubectl explain output and returns what the resource does,
+ * which providers it supports, and how complex it is to use.
+ *
+ * The output (ResourceCapability[]) feeds directly into M3's vector storage.
+ *
+ * Key design choices:
+ * - Uses Claude Haiku for speed and cost (batch-processing dozens of schemas)
+ * - Zod + withStructuredOutput() guarantees valid JSON responses
+ * - Sequential processing (cluster schemas total ~3 seconds, no need for parallelism)
+ * - Injectable model for testing (same DI pattern as DiscoveryOptions.kubectl)
+ */
+
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { z } from "zod";
+import * as fs from "fs";
+import * as path from "path";
+import type {
+  DiscoveredResource,
+  ResourceCapability,
+  LlmCapabilityResult,
+  InferenceOptions,
+} from "./types";
+
+const tracer = trace.getTracer("inference");
+
+// ---------------------------------------------------------------------------
+// Zod schema for structured LLM output
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema defining the shape of the LLM's structured response.
+ *
+ * Used with ChatAnthropic.withStructuredOutput() which leverages Anthropic's
+ * tool_use under the hood — the LLM is constrained to return valid JSON
+ * matching this schema. No manual JSON parsing or regex needed.
+ *
+ * The .describe() calls become part of the tool schema the LLM sees,
+ * helping it understand what each field means.
+ */
+export const LlmCapabilitySchema = z.object({
+  capabilities: z
+    .array(z.string())
+    .describe(
+      "Functional capabilities this resource provides, as lowercase search terms (e.g., 'database', 'postgresql', 'load-balancer')"
+    ),
+  providers: z
+    .array(z.string())
+    .describe(
+      "Cloud providers this resource supports, lowercase (e.g., 'aws', 'gcp', 'azure'). Empty array if provider-agnostic."
+    ),
+  complexity: z
+    .enum(["low", "medium", "high"])
+    .describe(
+      "How complex the resource is to use: 'low' = few fields, 'medium' = several fields, 'high' = many nested fields"
+    ),
+  description: z
+    .string()
+    .describe(
+      "1-2 sentence description of what this resource does, for a developer who has never seen it"
+    ),
+  useCase: z
+    .string()
+    .describe(
+      "When and why a developer would use this resource. Start with a verb like 'Deploy', 'Configure', 'Manage'."
+    ),
+  confidence: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe(
+      "Confidence in the analysis: 0.9+ for detailed schemas, 0.5-0.8 for sparse ones, below 0.5 for minimal info"
+    ),
+});
+
+// ---------------------------------------------------------------------------
+// Prompt template loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Path to the capability inference prompt template.
+ * Goes from src/pipeline/ up to project root, then into prompts/.
+ */
+const promptPath = path.join(
+  __dirname,
+  "../../prompts/capability-inference.md"
+);
+
+/** Cached prompt template — loaded lazily on first use. */
+let cachedPrompt: string | null = null;
+
+/**
+ * Loads the prompt template from disk, caching it for reuse.
+ * Provides a clear error message if the file is missing.
+ */
+function getPromptTemplate(): string {
+  if (!cachedPrompt) {
+    try {
+      cachedPrompt = fs.readFileSync(promptPath, "utf8");
+    } catch {
+      throw new Error(
+        `Could not load prompt template from ${promptPath}. ` +
+          `Make sure prompts/capability-inference.md exists in the project root.`
+      );
+    }
+  }
+  return cachedPrompt;
+}
+
+// ---------------------------------------------------------------------------
+// Default model creation
+// ---------------------------------------------------------------------------
+
+/**
+ * The Anthropic model used for batch capability inference.
+ *
+ * Haiku is chosen over Sonnet for this use case because:
+ * - We process dozens of schemas sequentially
+ * - Schema analysis doesn't need deep reasoning
+ * - Haiku is faster and cheaper for structured extraction
+ *
+ * Sonnet is reserved for the investigator agent where reasoning depth matters.
+ */
+const INFERENCE_MODEL = "claude-haiku-4-5-20251001";
+
+/** Cached default model — created lazily on first use. */
+let cachedModel: {
+  invoke: (messages: Array<[string, string]>) => Promise<LlmCapabilityResult>;
+} | null = null;
+
+/**
+ * Creates the default structured model for inference.
+ * Uses ChatAnthropic with withStructuredOutput() to guarantee valid JSON.
+ */
+function getDefaultModel(): {
+  invoke: (messages: Array<[string, string]>) => Promise<LlmCapabilityResult>;
+} {
+  if (!cachedModel) {
+    const llm = new ChatAnthropic({
+      model: INFERENCE_MODEL,
+      maxTokens: 1024,
+    });
+
+    // withStructuredOutput() wraps the model so it always returns parsed JSON
+    // matching our Zod schema. Under the hood, it uses Anthropic's tool_use
+    // feature to constrain the output format.
+    cachedModel = llm.withStructuredOutput(LlmCapabilitySchema) as unknown as {
+      invoke: (
+        messages: Array<[string, string]>
+      ) => Promise<LlmCapabilityResult>;
+    };
+  }
+  return cachedModel;
+}
+
+// ---------------------------------------------------------------------------
+// Inference functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the human message content for a single resource.
+ *
+ * Includes the resource name, kind, and full schema so the LLM has
+ * context about what it's analyzing. The system message (prompt template)
+ * provides the instructions.
+ */
+function buildHumanMessage(resource: DiscoveredResource): string {
+  return [
+    `Resource: ${resource.name}`,
+    `Kind: ${resource.kind}`,
+    `API Version: ${resource.apiVersion}`,
+    "",
+    "Schema (kubectl explain --recursive):",
+    "```",
+    resource.schema,
+    "```",
+  ].join("\n");
+}
+
+/**
+ * Infers capabilities for a single Kubernetes resource.
+ *
+ * Sends the resource's schema to the LLM with the prompt template and
+ * returns a ResourceCapability combining the resource metadata with the
+ * LLM's structured analysis.
+ *
+ * @param resource - A discovered resource with schema text from M1
+ * @param options - Injectable model and progress callback for testing
+ * @returns ResourceCapability with both metadata and LLM-inferred fields
+ * @throws Error with resource context if the LLM call fails
+ */
+export async function inferCapability(
+  resource: DiscoveredResource,
+  options?: InferenceOptions
+): Promise<ResourceCapability> {
+  return tracer.startActiveSpan("inference.infer_capability", async (span) => {
+    try {
+      span.setAttribute("resource.name", resource.name);
+      span.setAttribute("resource.kind", resource.kind);
+      span.setAttribute("resource.api_version", resource.apiVersion);
+      span.setAttribute("resource.group", resource.group ?? "");
+
+      const model = options?.model ?? getDefaultModel();
+
+      const messages: Array<[string, string]> = [
+        ["system", getPromptTemplate()],
+        ["human", buildHumanMessage(resource)],
+      ];
+
+      let llmResult: LlmCapabilityResult;
+      try {
+        llmResult = await tracer.startActiveSpan(
+          "llm.invoke",
+          async (llmSpan) => {
+            try {
+              llmSpan.setAttribute("llm.model", INFERENCE_MODEL);
+              llmSpan.setAttribute("llm.resource_name", resource.name);
+              return await model.invoke(messages);
+            } catch (error) {
+              llmSpan.recordException(error as Error);
+              llmSpan.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: (error as Error).message,
+              });
+              throw error;
+            } finally {
+              llmSpan.end();
+            }
+          }
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Failed to infer capabilities for ${resource.name}: ${message}`
+        );
+      }
+
+      const result: ResourceCapability = {
+        // Resource metadata from M1
+        resourceName: resource.name,
+        apiVersion: resource.apiVersion,
+        group: resource.group,
+        kind: resource.kind,
+        // LLM-inferred fields
+        ...llmResult,
+      };
+
+      span.setAttribute("llm.result.complexity", result.complexity);
+      span.setAttribute("llm.result.confidence", result.confidence);
+      span.setAttribute(
+        "llm.result.capabilities_count",
+        result.capabilities.length
+      );
+
+      return result;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: (error as Error).message,
+      });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Infers capabilities for multiple resources sequentially.
+ *
+ * Processes each resource one at a time, skipping any where the LLM fails.
+ * Reports progress via callback so callers can show "Inferring (3 of 47)".
+ *
+ * Why sequential and not parallel?
+ * - Total wall time for a cluster is typically under a minute
+ * - Sequential is simpler to debug and reason about
+ * - Avoids rate limit concerns with the Anthropic API
+ * - Progress reporting is clearer with sequential processing
+ *
+ * @param resources - Array of discovered resources from M1
+ * @param options - Injectable model and progress callback for testing
+ * @returns Array of ResourceCapability for successfully processed resources
+ */
+export async function inferCapabilities(
+  resources: DiscoveredResource[],
+  options?: InferenceOptions
+): Promise<ResourceCapability[]> {
+  return tracer.startActiveSpan(
+    "inference.infer_capabilities",
+    async (span) => {
+      try {
+        span.setAttribute("resources.count", resources.length);
+
+        const onProgress = options?.onProgress ?? console.log; // eslint-disable-line no-console
+        const results: ResourceCapability[] = [];
+
+        for (let i = 0; i < resources.length; i++) {
+          const resource = resources[i];
+          onProgress(
+            `Inferring capabilities (${i + 1} of ${resources.length}): ${resource.name}`
+          );
+
+          try {
+            const capability = await inferCapability(resource, options);
+            results.push(capability);
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            onProgress(`  Warning: skipping ${resource.name} (${message})`);
+          }
+        }
+
+        onProgress(
+          `Inference complete: ${results.length} of ${resources.length} resources processed.`
+        );
+
+        span.setAttribute("resources.processed_count", results.length);
+        span.setAttribute(
+          "resources.skipped_count",
+          resources.length - results.length
+        );
+
+        return results;
+      } catch (error) {
+        span.recordException(error as Error);
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: (error as Error).message,
+        });
+        throw error;
+      } finally {
+        span.end();
+      }
+    }
+  );
+}

--- a/src/ts-samples/pipeline/types.ts
+++ b/src/ts-samples/pipeline/types.ts
@@ -1,0 +1,240 @@
+/**
+ * types.ts - Shared data types for the capability and instance pipelines
+ *
+ * These types flow through the pipeline milestones:
+ *
+ * Capability Inference (PRD #25):
+ * - M1 (Discovery) produces DiscoveredResource[]
+ * - M2 (Inference) consumes DiscoveredResource[], produces ResourceCapability[]
+ * - M3 (Storage) consumes ResourceCapability[], stores in vector DB
+ *
+ * Resource Instance Sync (PRD #26):
+ * - M1 (Discovery) produces ResourceInstance[]
+ * - M2 (Storage) consumes ResourceInstance[], stores in vector DB
+ */
+
+/**
+ * Intermediate representation from parsing kubectl api-resources output.
+ * Contains metadata about a Kubernetes resource type before schema extraction.
+ */
+export interface ParsedApiResource {
+  /** Plural resource name (e.g., "deployments", "sqls") */
+  name: string;
+  /** Comma-separated short names (e.g., "deploy"), empty string if none */
+  shortNames: string;
+  /** Full API version (e.g., "apps/v1", "v1", "devopstoolkit.live/v1beta1") */
+  apiVersion: string;
+  /** Whether resources of this type are namespace-scoped */
+  namespaced: boolean;
+  /** Kind name (e.g., "Deployment", "SQL") */
+  kind: string;
+  /** Available API verbs (e.g., ["get", "list", "create"]) */
+  verbs: string[];
+  /** Resource categories (e.g., ["all"]), empty array if none */
+  categories: string[];
+}
+
+/**
+ * A fully discovered resource with its schema, ready for LLM analysis in M2.
+ * This is the final output of the M1 discovery pipeline.
+ */
+export interface DiscoveredResource {
+  /** Fully qualified resource name (e.g., "deployments.apps", "sqls.devopstoolkit.live") */
+  name: string;
+  /** Full API version (e.g., "apps/v1", "devopstoolkit.live/v1beta1") */
+  apiVersion: string;
+  /** API group (e.g., "apps", "devopstoolkit.live", "" for core) */
+  group: string;
+  /** Kind name (e.g., "Deployment", "SQL") */
+  kind: string;
+  /** Whether resources of this type are namespace-scoped */
+  namespaced: boolean;
+  /** Whether this is a Custom Resource Definition */
+  isCRD: boolean;
+  /** kubectl explain --recursive output for LLM analysis */
+  schema: string;
+}
+
+/**
+ * Options for the discoverResources function.
+ * Accepts injectable dependencies for testing.
+ */
+export interface DiscoveryOptions {
+  /**
+   * Injectable kubectl executor for testing.
+   * Defaults to the real executeKubectl from utils/kubectl.
+   */
+  kubectl?: (args: string[]) => { output: string; isError: boolean };
+  /**
+   * Progress callback for long-running operations.
+   * Called during schema extraction with messages like "Extracting schemas... (3 of 47)"
+   * Defaults to stdout.
+   */
+  onProgress?: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// PRD #26: Resource Instance Sync types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single running resource instance discovered from the cluster.
+ *
+ * Represents an actual deployed object (e.g., a specific nginx Deployment)
+ * as opposed to a resource *type* (e.g., the Deployment kind itself).
+ * This is the output of PRD #26's M1 discovery and the input to M2 storage.
+ *
+ * The metadata here is intentionally lightweight — spec, status, and
+ * managedFields are NOT synced. The agent fetches those on-demand via
+ * kubectl tools when it needs details about a specific instance.
+ */
+export interface ResourceInstance {
+  /**
+   * Canonical identifier for this instance.
+   * Format: "namespace/apiVersion/Kind/name"
+   * Example: "default/apps/v1/Deployment/nginx"
+   * For cluster-scoped resources: "_cluster/v1/Namespace/kube-system"
+   */
+  id: string;
+  /** Namespace the instance lives in, or "_cluster" for cluster-scoped resources */
+  namespace: string;
+  /** Instance name from metadata.name */
+  name: string;
+  /** Resource kind (e.g., "Deployment", "Service", "SQL") */
+  kind: string;
+  /** Full API version (e.g., "apps/v1", "v1") */
+  apiVersion: string;
+  /** API group (e.g., "apps", "" for core resources) */
+  apiGroup: string;
+  /** All labels from metadata.labels */
+  labels: Record<string, string>;
+  /** Filtered annotations — only description-like annotations are kept */
+  annotations: Record<string, string>;
+  /** ISO timestamp from metadata.creationTimestamp */
+  createdAt: string;
+}
+
+/**
+ * Options for the discoverInstances function.
+ * Accepts injectable dependencies for testing, following the same
+ * pattern as DiscoveryOptions for capability inference.
+ */
+export interface InstanceDiscoveryOptions {
+  /**
+   * Injectable kubectl executor for testing.
+   * Defaults to the real executeKubectl from utils/kubectl.
+   */
+  kubectl?: (args: string[]) => { output: string; isError: boolean };
+  /**
+   * Progress callback for long-running operations.
+   * Called with messages like "Listing instances (3 of 47): deployments.apps"
+   * Defaults to stdout.
+   */
+  onProgress?: (message: string) => void;
+  /**
+   * Optional: only sync instances of these resource types.
+   * Uses plural resource names (e.g., ["deployments", "services", "sqls"]).
+   * When omitted, discovers and syncs all resource types.
+   */
+  resourceTypes?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// M2: LLM Inference types
+// ---------------------------------------------------------------------------
+
+/**
+ * A structured capability description for a Kubernetes resource type.
+ *
+ * Combines metadata from the cluster (resourceName, apiVersion, group, kind)
+ * with LLM-inferred semantic fields (capabilities, providers, complexity,
+ * description, useCase, confidence).
+ *
+ * This is the main data structure that flows from M2 (inference) into M3
+ * (vector storage) and ultimately powers semantic search — "how do I deploy
+ * a database?" matches resources whose capabilities include "database".
+ */
+export interface ResourceCapability {
+  /** Fully qualified resource name (e.g., "sqls.devopstoolkit.live") */
+  resourceName: string;
+  /** Full API version (e.g., "devopstoolkit.live/v1beta1") */
+  apiVersion: string;
+  /** API group (e.g., "devopstoolkit.live", "" for core) */
+  group: string;
+  /** Kind name (e.g., "SQL") */
+  kind: string;
+
+  // --- LLM-inferred fields below ---
+
+  /** Functional capabilities this resource provides (e.g., ["postgresql", "mysql", "database"]) */
+  capabilities: string[];
+  /** Cloud providers this resource supports (e.g., ["aws", "gcp", "azure"]) */
+  providers: string[];
+  /** How complex the resource is to use */
+  complexity: "low" | "medium" | "high";
+  /** Human-readable description of what the resource does */
+  description: string;
+  /** When and why a developer would use this resource */
+  useCase: string;
+  /** LLM's confidence in its analysis (0 = guessing, 1 = certain) */
+  confidence: number;
+}
+
+/**
+ * The subset of ResourceCapability fields that come from the LLM.
+ *
+ * Derived from ResourceCapability via Omit so the two types stay structurally
+ * coupled. The remaining fields (resourceName, apiVersion, group, kind) are
+ * copied from the DiscoveredResource input — no need for the LLM to repeat them.
+ */
+export type LlmCapabilityResult = Omit<
+  ResourceCapability,
+  "resourceName" | "apiVersion" | "group" | "kind"
+>;
+
+/**
+ * Options for the inference pipeline functions.
+ * Accepts injectable dependencies for testing.
+ */
+export interface InferenceOptions {
+  /**
+   * Injectable structured model for testing.
+   *
+   * Must accept an array of BaseMessage-like objects and return the
+   * LLM-inferred fields. In production, this is a ChatAnthropic instance
+   * with withStructuredOutput(). In tests, a simple mock object.
+   *
+   * Defaults to ChatAnthropic Haiku with Zod structured output.
+   */
+  model?: {
+    invoke: (messages: Array<[string, string]>) => Promise<LlmCapabilityResult>;
+  };
+  /**
+   * Progress callback for long-running operations.
+   * Called with messages like "Inferring capabilities (3 of 47): sqls.devopstoolkit.live"
+   * Defaults to stdout.
+   */
+  onProgress?: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// M3: Storage types
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for the storage pipeline functions.
+ * Accepts injectable dependencies for testing.
+ *
+ * The VectorStore is injected rather than imported directly so that:
+ * - Unit tests can use a mock (no Chroma server needed)
+ * - Integration tests can use a real ChromaBackend
+ * - The storage code stays backend-agnostic
+ */
+export interface StorageOptions {
+  /**
+   * Progress callback for long-running operations.
+   * Called with messages like "Storing capabilities (3 of 47)"
+   * Defaults to stdout.
+   */
+  onProgress?: (message: string) => void;
+}

--- a/src/ts-samples/tools/format-results.ts
+++ b/src/ts-samples/tools/format-results.ts
@@ -1,0 +1,126 @@
+/**
+ * format-results.ts - Formats vector search results for LLM consumption
+ *
+ * What this file does:
+ * Converts raw SearchResult arrays from the vector database into readable
+ * text that the LLM can understand and reason about. Both the semantic search
+ * and filter query tools use this same formatter.
+ *
+ * Why a shared formatter?
+ * Both vector tools return the same SearchResult type. Formatting once keeps
+ * the output consistent and avoids duplicating the presentation logic.
+ *
+ * Design choices:
+ * - Plain text, not JSON — LLMs read prose better than structured data
+ * - Score included with explanation — so the LLM understands relevance
+ * - Metadata on a separate line — easy to scan for kind, apiGroup, etc.
+ * - Numbered results — helps the LLM reference specific items
+ */
+
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import type { SearchResult } from "../../vectorstore";
+
+const tracer = trace.getTracer('commit-story.tools.format-results');
+
+/**
+ * Formats an array of search results into LLM-readable text.
+ *
+ * Example output:
+ *   Found 3 results in "capabilities" collection:
+ *
+ *   1. apps/v1/Deployment (distance: 0.15 — very similar)
+ *      Manages replicated application pods with rolling updates...
+ *      Metadata: kind=Deployment, apiGroup=apps, version=v1
+ *
+ *   2. acid.zalan.do/v1/postgresql (distance: 0.32 — similar)
+ *      ...
+ *
+ * @param results - Search results from VectorStore.search()
+ * @param collection - Which collection was searched (for the header)
+ * @returns Formatted string for the LLM to read
+ */
+export function formatSearchResults(
+  results: SearchResult[],
+  collection: string
+): string {
+  return tracer.startActiveSpan('format.search.results', (span) => {
+    try {
+      span.setAttribute('search.collection', collection);
+      span.setAttribute('search.results.count', results.length);
+
+      if (results.length === 0) {
+        return `No results found in "${collection}" collection.`;
+      }
+
+      const header = `Found ${results.length} result${results.length === 1 ? "" : "s"} in "${collection}" collection:\n`;
+
+      const formatted = results.map((result, index) => {
+        // Score of -1 means keyword/filter match (no vector comparison).
+        // Show "keyword match" instead of a meaningless distance number.
+        const scoreLabel =
+          result.score < 0
+            ? "keyword match"
+            : `distance: ${result.score.toFixed(2)} — ${describeSimilarity(result.score)}`;
+        const metadataLine = formatMetadata(result.metadata);
+
+        const lines = [
+          `${index + 1}. ${result.id} (${scoreLabel})`,
+          `   ${result.text}`,
+        ];
+
+        if (metadataLine) {
+          lines.push(`   Metadata: ${metadataLine}`);
+        }
+
+        return lines.join("\n");
+      });
+
+      return header + "\n" + formatted.join("\n\n");
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Cosine distance thresholds for similarity labels.
+ * Tuning deferred to PRD #25 M3 when real data is available.
+ */
+const VERY_SIMILAR_THRESHOLD = 0.3;
+const SIMILAR_THRESHOLD = 0.6;
+const SOMEWHAT_RELATED_THRESHOLD = 1.0;
+
+/**
+ * Converts a cosine distance score into a human-readable similarity label.
+ *
+ * Cosine distance ranges:
+ * - 0.0 = identical vectors (perfect match)
+ * - 0.0–0.3 = very similar (strong semantic match)
+ * - 0.3–0.6 = similar (related content)
+ * - 0.6–1.0 = somewhat related (weak match)
+ * - 1.0–2.0 = dissimilar to opposite
+ */
+function describeSimilarity(score: number): string {
+  if (score < VERY_SIMILAR_THRESHOLD) return "very similar";
+  if (score < SIMILAR_THRESHOLD) return "similar";
+  if (score < SOMEWHAT_RELATED_THRESHOLD) return "somewhat related";
+  return "weak match";
+}
+
+/**
+ * Formats metadata key-value pairs into a readable string.
+ *
+ * Skips empty metadata. Joins pairs with commas.
+ * Example: "kind=Deployment, apiGroup=apps, version=v1"
+ */
+function formatMetadata(
+  metadata: Record<string, string | number | boolean>
+): string {
+  const entries = Object.entries(metadata);
+  if (entries.length === 0) return "";
+  return entries.map(([key, value]) => `${key}=${value}`).join(", ");
+}

--- a/src/ts-samples/tools/kubectl-get.ts
+++ b/src/ts-samples/tools/kubectl-get.ts
@@ -1,0 +1,123 @@
+/**
+ * kubectl-get core - Shared logic for listing Kubernetes resources
+ *
+ * This module contains the pure business logic for kubectl get, separate from
+ * any framework (LangChain, MCP). Both the CLI agent and MCP server import
+ * from here, ensuring consistent behavior across interfaces.
+ *
+ * Why separate core logic?
+ * - CLI uses LangChain's tool() wrapper
+ * - MCP uses @modelcontextprotocol/sdk's tool registration
+ * - Both need the same schema validation and kubectl execution
+ * - Extracting the core avoids duplicating logic and keeps behavior consistent
+ */
+
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { z } from "zod";
+import { executeKubectl, KubectlResult } from "../../utils/kubectl";
+
+const tracer = trace.getTracer("kubectl-get");
+
+/**
+ * Input schema for kubectl get.
+ *
+ * Why Zod?
+ * Zod validates inputs at runtime and generates JSON Schema for tool definitions.
+ * Both LangChain and MCP use this same schema, just wrapped differently.
+ *
+ * Fields:
+ * - resource: Required. What kind of thing to list (pods, deployments, etc.)
+ * - namespace: Optional. Where to look. Omit for current context, "all" for everywhere.
+ * - name: Optional. Get one specific resource instead of listing all.
+ */
+export const kubectlGetSchema = z.object({
+  resource: z
+    .string()
+    .describe(
+      "The type of Kubernetes resource to list (e.g., 'pods', 'deployments', 'services', 'nodes')"
+    ),
+  namespace: z
+    .string()
+    .optional()
+    .describe(
+      "The namespace to query. Omit to use the current context's default namespace, or use 'all' for all namespaces"
+    ),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      "Specific resource name to get. Omit to list all resources of this type"
+    ),
+});
+
+/**
+ * TypeScript type derived from the schema.
+ * Use this to get compile-time type checking for inputs.
+ */
+export type KubectlGetInput = z.infer<typeof kubectlGetSchema>;
+
+/**
+ * Tool description for LLMs.
+ * Both LangChain and MCP tools use this same description so the AI
+ * understands when and how to use the tool, regardless of which
+ * interface it's accessing.
+ */
+export const kubectlGetDescription = `List Kubernetes resources in TABLE FORMAT (compact, one line per resource).
+
+Returns columns like NAME, STATUS, READY, AGE. Use this to:
+- See what resources exist in a namespace or cluster
+- Check basic status (Running, Pending, CrashLoopBackOff, etc.)
+- Find resources that need further investigation
+
+For detailed information about a specific resource (events, configuration,
+conditions), use kubectl_describe instead.
+
+Common resources: pods, deployments, services, nodes, configmaps, namespaces.`;
+
+/**
+ * Execute kubectl get with the given parameters.
+ *
+ * This is the actual work - building the command and running it.
+ * Framework wrappers (LangChain, MCP) call this function.
+ *
+ * @param input - Validated input matching kubectlGetSchema
+ * @returns KubectlResult with output string and isError flag
+ */
+export async function kubectlGet(input: KubectlGetInput): Promise<KubectlResult> {
+  return tracer.startActiveSpan("kubectl.get", async (span) => {
+    try {
+      const { resource, namespace, name } = input;
+
+      span.setAttribute("kubectl.resource", resource);
+      if (namespace !== undefined) {
+        span.setAttribute("kubectl.namespace", namespace);
+      }
+      if (name !== undefined) {
+        span.setAttribute("kubectl.name", name);
+      }
+
+      // Build kubectl arguments: kubectl get <resource> [name] [-n namespace | -A]
+      const args: string[] = ["get", resource];
+
+      // Handle namespace: "all" means all namespaces, otherwise specific namespace
+      if (namespace === "all") {
+        args.push("-A");
+      } else if (namespace) {
+        args.push("-n", namespace);
+      }
+
+      // Add specific resource name if provided
+      if (name) {
+        args.push(name);
+      }
+
+      return await executeKubectl(args);
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/src/ts-samples/tracing/index.ts
+++ b/src/ts-samples/tracing/index.ts
@@ -1,0 +1,6 @@
+// Stub for evaluation — provides getTracer used by kubectl.ts
+import { trace } from "@opentelemetry/api";
+
+export function getTracer() {
+  return trace.getTracer("commit-story-v2-eval");
+}

--- a/src/ts-samples/utils/kubectl.ts
+++ b/src/ts-samples/utils/kubectl.ts
@@ -1,0 +1,279 @@
+/**
+ * kubectl.ts - Executes kubectl commands as subprocesses
+ *
+ * How it works:
+ * 1. Takes an array of kubectl arguments (e.g., ["get", "pods", "-n", "default"])
+ * 2. Spawns kubectl as a child process
+ * 3. Returns the output as a string, or an error message if it fails
+ *
+ * Why spawnSync instead of execSync?
+ * Both are synchronous (block until complete), but they differ in how they
+ * handle arguments:
+ *
+ * - execSync(string): Passes the string to a shell (/bin/sh -c "...").
+ *   This means shell metacharacters like ; | ` $() are interpreted.
+ *   If args contained ["get", "pods; rm -rf /"], the shell would see TWO
+ *   commands: "kubectl get pods" AND "rm -rf /". This is shell injection.
+ *
+ * - spawnSync(cmd, args[]): Bypasses the shell entirely. Each array element
+ *   becomes a separate argument to the process. The string "pods; rm -rf /"
+ *   is passed as a single argument to kubectl, which safely fails with
+ *   "resource not found" instead of executing the injected command.
+ *
+ * Rule of thumb: Always use spawnSync with an args array when the arguments
+ * come from any external source (user input, API calls, AI agents).
+ *
+ * OpenTelemetry instrumentation:
+ * Each kubectl execution creates a span following OTel semantic conventions.
+ * We use process.* semconv attributes plus two pragmatic custom attributes
+ * (cluster_whisperer.k8s.namespace and cluster_whisperer.k8s.output_size_bytes) that have no semconv equivalent.
+ * See docs/opentelemetry-research.md Section 10 for the semconv gap analysis.
+ */
+
+import { spawnSync } from "child_process";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "../tracing";
+
+/**
+ * Flags that may contain sensitive values (tokens, passwords, keys).
+ * These are redacted from span attributes to prevent leaking secrets to telemetry.
+ */
+const SENSITIVE_FLAGS = new Set([
+  "--token",
+  "--password",
+  "--client-key",
+  "--client-certificate",
+  "--kubeconfig",
+]);
+
+/**
+ * Redact sensitive kubectl arguments before adding to span attributes.
+ *
+ * Some kubectl flags can contain secrets (--token, --password, etc.) that
+ * should not be exported to telemetry backends. This function replaces
+ * the values of known sensitive flags with "[REDACTED]".
+ *
+ * @param args - kubectl arguments array
+ * @returns New array with sensitive values redacted
+ */
+function redactSensitiveArgs(args: string[]): string[] {
+  const redacted: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // Check for --flag=value format
+    for (const flag of SENSITIVE_FLAGS) {
+      if (arg.startsWith(`${flag}=`)) {
+        redacted.push(`${flag}=[REDACTED]`);
+        continue;
+      }
+    }
+
+    // Check for --flag value format (two separate args)
+    if (SENSITIVE_FLAGS.has(arg) && i + 1 < args.length) {
+      redacted.push(arg);
+      redacted.push("[REDACTED]");
+      i++; // Skip the next arg (the value)
+      continue;
+    }
+
+    // Not sensitive, keep as-is
+    redacted.push(arg);
+  }
+
+  return redacted;
+}
+
+/**
+ * Result from executing a kubectl command.
+ *
+ * Why a structured result instead of just a string?
+ * MCP tool responses include an `isError` flag to signal failures to clients.
+ * Previously we detected errors by checking if output started with "Error",
+ * but this caused false positives when legitimate output (like application logs)
+ * contained error messages. By returning the error state explicitly based on
+ * kubectl's exit code, we avoid content-based detection entirely.
+ */
+export interface KubectlResult {
+  output: string;
+  isError: boolean;
+}
+
+/**
+ * Metadata extracted from kubectl args for tracing attributes.
+ * We parse this from the args array to create meaningful span names
+ * and attributes without changing the executeKubectl API.
+ */
+interface KubectlMetadata {
+  operation: string; // get, describe, logs
+  resource: string; // pods, deployments, etc.
+  namespace: string | undefined; // from -n flag
+}
+
+/**
+ * Extracts operation metadata from kubectl args for tracing.
+ *
+ * Kubectl commands follow predictable patterns:
+ * - kubectl get pods -n default     → operation=get, resource=pods
+ * - kubectl describe pod nginx      → operation=describe, resource=pod
+ * - kubectl logs nginx -n default   → operation=logs, resource=nginx (pod name)
+ *
+ * @param args - kubectl arguments (without "kubectl" itself)
+ * @returns Metadata for span naming and attributes
+ */
+function extractKubectlMetadata(args: string[]): KubectlMetadata {
+  // Operation is always the first argument
+  const operation = args[0] || "unknown";
+
+  // Resource is typically the second argument
+  // For logs, this is the pod name; for get/describe, it's the resource type
+  const resource = args[1] || "unknown";
+
+  // Find namespace from -n or --namespace flag
+  let namespaceIndex = args.indexOf("-n");
+  if (namespaceIndex === -1) {
+    namespaceIndex = args.indexOf("--namespace");
+  }
+  const namespace =
+    namespaceIndex !== -1 && args[namespaceIndex + 1]
+      ? args[namespaceIndex + 1]
+      : undefined;
+
+  return { operation, resource, namespace };
+}
+
+/**
+ * Executes a kubectl command and returns a structured result.
+ *
+ * Creates an OpenTelemetry span for the kubectl subprocess execution with:
+ * - Span name: "kubectl {operation} {resource}" (e.g., "kubectl get pods")
+ * - Span kind: CLIENT (outbound subprocess call)
+ * - Attributes: OTel semconv process.* attributes plus cluster_whisperer.k8s.namespace and cluster_whisperer.k8s.output_size_bytes
+ *
+ * The span is automatically parented under the active MCP tool span (if any),
+ * creating the hierarchy: execute_tool kubectl_get → kubectl get pods
+ *
+ * @param args - Array of arguments to pass to kubectl (e.g., ["get", "pods"])
+ * @returns Object with output string and isError flag based on exit code
+ *
+ * Example:
+ *   executeKubectl(["get", "pods", "-n", "default"])
+ *   // Returns: { output: "NAME  READY  STATUS...", isError: false }
+ *
+ *   executeKubectl(["get", "nonexistent"])
+ *   // Returns: { output: "Error executing...", isError: true }
+ */
+export function executeKubectl(args: string[]): KubectlResult {
+  const tracer = getTracer();
+  const metadata = extractKubectlMetadata(args);
+
+  // Build the full command for display purposes (logging only, not execution)
+  const command = `kubectl ${args.join(" ")}`;
+
+  // Span name follows Viktor's pattern: "kubectl {operation} {resource}"
+  // SpanKind.CLIENT = outbound call (we're calling kubectl subprocess)
+  return tracer.startActiveSpan(
+    `kubectl ${metadata.operation} ${metadata.resource}`,
+    { kind: SpanKind.CLIENT },
+    (span) => {
+      // Set pre-execution attributes
+      // OTel semconv process.* attributes
+      // Redact sensitive flags (--token, --password, etc.) before adding to span
+      span.setAttribute("process.executable.name", "kubectl");
+      span.setAttribute("process.command_args", [
+        "kubectl",
+        ...redactSensitiveArgs(args),
+      ]);
+
+      // Pragmatic custom attributes (no semconv equivalent, namespaced to project)
+      // cluster_whisperer.k8s.namespace is useful for filtering queries by namespace
+      if (metadata.namespace) {
+        span.setAttribute("cluster_whisperer.k8s.namespace", metadata.namespace);
+      }
+
+      try {
+        // spawnSync bypasses the shell - each array element is a separate argument.
+        // This prevents shell injection even if args contain malicious characters.
+        const result = spawnSync("kubectl", args, {
+          encoding: "utf-8", // Return strings instead of Buffers
+          timeout: 30000, // 30 second timeout to avoid hanging
+        });
+
+        // Handle spawn errors (e.g., kubectl not found)
+        if (result.error) {
+          span.setAttribute("process.exit.code", -1);
+          span.setAttribute("error.type", result.error.name);
+          span.recordException(result.error);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: result.error.message,
+          });
+
+          return {
+            output: `Error executing "${command}": ${result.error.message}`,
+            isError: true,
+          };
+        }
+
+        // Set exit code (semconv attribute)
+        span.setAttribute("process.exit.code", result.status ?? -1);
+
+        // Handle non-zero exit codes (e.g., resource not found, permission denied)
+        if (result.status !== 0) {
+          const errorMessage = result.stderr || "Unknown error";
+          span.setAttribute("error.type", "KubectlError");
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: errorMessage,
+          });
+
+          return {
+            output: `Error executing "${command}": ${errorMessage}`,
+            isError: true,
+          };
+        }
+
+        // Success case
+        // cluster_whisperer.k8s.output_size_bytes is a pragmatic custom attribute (no semconv equivalent)
+        // Useful for debugging when kubectl returns unexpectedly large output
+        span.setAttribute(
+          "cluster_whisperer.k8s.output_size_bytes",
+          Buffer.byteLength(result.stdout, "utf-8")
+        );
+        span.setStatus({ code: SpanStatusCode.OK });
+
+        return {
+          output: result.stdout,
+          isError: false,
+        };
+      } catch (error) {
+        // Unexpected error during execution
+        span.setAttribute("process.exit.code", -1);
+
+        if (error instanceof Error) {
+          span.setAttribute("error.type", error.name);
+          span.recordException(error);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error.message,
+          });
+        } else {
+          span.setAttribute("error.type", "UnknownError");
+          span.recordException(new Error(String(error)));
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: String(error),
+          });
+        }
+
+        return {
+          output: `Error executing "${command}": ${error instanceof Error ? error.message : String(error)}`,
+          isError: true,
+        };
+      } finally {
+        span.end();
+      }
+    }
+  );
+}

--- a/src/utils/kubectl.ts
+++ b/src/utils/kubectl.ts
@@ -1,0 +1,279 @@
+/**
+ * kubectl.ts - Executes kubectl commands as subprocesses
+ *
+ * How it works:
+ * 1. Takes an array of kubectl arguments (e.g., ["get", "pods", "-n", "default"])
+ * 2. Spawns kubectl as a child process
+ * 3. Returns the output as a string, or an error message if it fails
+ *
+ * Why spawnSync instead of execSync?
+ * Both are synchronous (block until complete), but they differ in how they
+ * handle arguments:
+ *
+ * - execSync(string): Passes the string to a shell (/bin/sh -c "...").
+ *   This means shell metacharacters like ; | ` $() are interpreted.
+ *   If args contained ["get", "pods; rm -rf /"], the shell would see TWO
+ *   commands: "kubectl get pods" AND "rm -rf /". This is shell injection.
+ *
+ * - spawnSync(cmd, args[]): Bypasses the shell entirely. Each array element
+ *   becomes a separate argument to the process. The string "pods; rm -rf /"
+ *   is passed as a single argument to kubectl, which safely fails with
+ *   "resource not found" instead of executing the injected command.
+ *
+ * Rule of thumb: Always use spawnSync with an args array when the arguments
+ * come from any external source (user input, API calls, AI agents).
+ *
+ * OpenTelemetry instrumentation:
+ * Each kubectl execution creates a span following OTel semantic conventions.
+ * We use process.* semconv attributes plus two pragmatic custom attributes
+ * (cluster_whisperer.k8s.namespace and cluster_whisperer.k8s.output_size_bytes) that have no semconv equivalent.
+ * See docs/opentelemetry-research.md Section 10 for the semconv gap analysis.
+ */
+
+import { spawnSync } from "child_process";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { getTracer } from "../tracing";
+
+/**
+ * Flags that may contain sensitive values (tokens, passwords, keys).
+ * These are redacted from span attributes to prevent leaking secrets to telemetry.
+ */
+const SENSITIVE_FLAGS = new Set([
+  "--token",
+  "--password",
+  "--client-key",
+  "--client-certificate",
+  "--kubeconfig",
+]);
+
+/**
+ * Redact sensitive kubectl arguments before adding to span attributes.
+ *
+ * Some kubectl flags can contain secrets (--token, --password, etc.) that
+ * should not be exported to telemetry backends. This function replaces
+ * the values of known sensitive flags with "[REDACTED]".
+ *
+ * @param args - kubectl arguments array
+ * @returns New array with sensitive values redacted
+ */
+function redactSensitiveArgs(args: string[]): string[] {
+  const redacted: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // Check for --flag=value format
+    for (const flag of SENSITIVE_FLAGS) {
+      if (arg.startsWith(`${flag}=`)) {
+        redacted.push(`${flag}=[REDACTED]`);
+        continue;
+      }
+    }
+
+    // Check for --flag value format (two separate args)
+    if (SENSITIVE_FLAGS.has(arg) && i + 1 < args.length) {
+      redacted.push(arg);
+      redacted.push("[REDACTED]");
+      i++; // Skip the next arg (the value)
+      continue;
+    }
+
+    // Not sensitive, keep as-is
+    redacted.push(arg);
+  }
+
+  return redacted;
+}
+
+/**
+ * Result from executing a kubectl command.
+ *
+ * Why a structured result instead of just a string?
+ * MCP tool responses include an `isError` flag to signal failures to clients.
+ * Previously we detected errors by checking if output started with "Error",
+ * but this caused false positives when legitimate output (like application logs)
+ * contained error messages. By returning the error state explicitly based on
+ * kubectl's exit code, we avoid content-based detection entirely.
+ */
+export interface KubectlResult {
+  output: string;
+  isError: boolean;
+}
+
+/**
+ * Metadata extracted from kubectl args for tracing attributes.
+ * We parse this from the args array to create meaningful span names
+ * and attributes without changing the executeKubectl API.
+ */
+interface KubectlMetadata {
+  operation: string; // get, describe, logs
+  resource: string; // pods, deployments, etc.
+  namespace: string | undefined; // from -n flag
+}
+
+/**
+ * Extracts operation metadata from kubectl args for tracing.
+ *
+ * Kubectl commands follow predictable patterns:
+ * - kubectl get pods -n default     → operation=get, resource=pods
+ * - kubectl describe pod nginx      → operation=describe, resource=pod
+ * - kubectl logs nginx -n default   → operation=logs, resource=nginx (pod name)
+ *
+ * @param args - kubectl arguments (without "kubectl" itself)
+ * @returns Metadata for span naming and attributes
+ */
+function extractKubectlMetadata(args: string[]): KubectlMetadata {
+  // Operation is always the first argument
+  const operation = args[0] || "unknown";
+
+  // Resource is typically the second argument
+  // For logs, this is the pod name; for get/describe, it's the resource type
+  const resource = args[1] || "unknown";
+
+  // Find namespace from -n or --namespace flag
+  let namespaceIndex = args.indexOf("-n");
+  if (namespaceIndex === -1) {
+    namespaceIndex = args.indexOf("--namespace");
+  }
+  const namespace =
+    namespaceIndex !== -1 && args[namespaceIndex + 1]
+      ? args[namespaceIndex + 1]
+      : undefined;
+
+  return { operation, resource, namespace };
+}
+
+/**
+ * Executes a kubectl command and returns a structured result.
+ *
+ * Creates an OpenTelemetry span for the kubectl subprocess execution with:
+ * - Span name: "kubectl {operation} {resource}" (e.g., "kubectl get pods")
+ * - Span kind: CLIENT (outbound subprocess call)
+ * - Attributes: OTel semconv process.* attributes plus cluster_whisperer.k8s.namespace and cluster_whisperer.k8s.output_size_bytes
+ *
+ * The span is automatically parented under the active MCP tool span (if any),
+ * creating the hierarchy: execute_tool kubectl_get → kubectl get pods
+ *
+ * @param args - Array of arguments to pass to kubectl (e.g., ["get", "pods"])
+ * @returns Object with output string and isError flag based on exit code
+ *
+ * Example:
+ *   executeKubectl(["get", "pods", "-n", "default"])
+ *   // Returns: { output: "NAME  READY  STATUS...", isError: false }
+ *
+ *   executeKubectl(["get", "nonexistent"])
+ *   // Returns: { output: "Error executing...", isError: true }
+ */
+export function executeKubectl(args: string[]): KubectlResult {
+  const tracer = getTracer();
+  const metadata = extractKubectlMetadata(args);
+
+  // Build the full command for display purposes (logging only, not execution)
+  const command = `kubectl ${args.join(" ")}`;
+
+  // Span name follows Viktor's pattern: "kubectl {operation} {resource}"
+  // SpanKind.CLIENT = outbound call (we're calling kubectl subprocess)
+  return tracer.startActiveSpan(
+    `kubectl ${metadata.operation} ${metadata.resource}`,
+    { kind: SpanKind.CLIENT },
+    (span) => {
+      // Set pre-execution attributes
+      // OTel semconv process.* attributes
+      // Redact sensitive flags (--token, --password, etc.) before adding to span
+      span.setAttribute("process.executable.name", "kubectl");
+      span.setAttribute("process.command_args", [
+        "kubectl",
+        ...redactSensitiveArgs(args),
+      ]);
+
+      // Pragmatic custom attributes (no semconv equivalent, namespaced to project)
+      // cluster_whisperer.k8s.namespace is useful for filtering queries by namespace
+      if (metadata.namespace) {
+        span.setAttribute("cluster_whisperer.k8s.namespace", metadata.namespace);
+      }
+
+      try {
+        // spawnSync bypasses the shell - each array element is a separate argument.
+        // This prevents shell injection even if args contain malicious characters.
+        const result = spawnSync("kubectl", args, {
+          encoding: "utf-8", // Return strings instead of Buffers
+          timeout: 30000, // 30 second timeout to avoid hanging
+        });
+
+        // Handle spawn errors (e.g., kubectl not found)
+        if (result.error) {
+          span.setAttribute("process.exit.code", -1);
+          span.setAttribute("error.type", result.error.name);
+          span.recordException(result.error);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: result.error.message,
+          });
+
+          return {
+            output: `Error executing "${command}": ${result.error.message}`,
+            isError: true,
+          };
+        }
+
+        // Set exit code (semconv attribute)
+        span.setAttribute("process.exit.code", result.status ?? -1);
+
+        // Handle non-zero exit codes (e.g., resource not found, permission denied)
+        if (result.status !== 0) {
+          const errorMessage = result.stderr || "Unknown error";
+          span.setAttribute("error.type", "KubectlError");
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: errorMessage,
+          });
+
+          return {
+            output: `Error executing "${command}": ${errorMessage}`,
+            isError: true,
+          };
+        }
+
+        // Success case
+        // cluster_whisperer.k8s.output_size_bytes is a pragmatic custom attribute (no semconv equivalent)
+        // Useful for debugging when kubectl returns unexpectedly large output
+        span.setAttribute(
+          "cluster_whisperer.k8s.output_size_bytes",
+          Buffer.byteLength(result.stdout, "utf-8")
+        );
+        span.setStatus({ code: SpanStatusCode.OK });
+
+        return {
+          output: result.stdout,
+          isError: false,
+        };
+      } catch (error) {
+        // Unexpected error during execution
+        span.setAttribute("process.exit.code", -1);
+
+        if (error instanceof Error) {
+          span.setAttribute("error.type", error.name);
+          span.recordException(error);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error.message,
+          });
+        } else {
+          span.setAttribute("error.type", "UnknownError");
+          span.recordException(new Error(String(error)));
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: String(error),
+          });
+        }
+
+        return {
+          output: `Error executing "${command}": ${error instanceof Error ? error.message : String(error)}`,
+          isError: true,
+        };
+      } finally {
+        span.end();
+      }
+    }
+  );
+}

--- a/src/vectorstore/index.ts
+++ b/src/vectorstore/index.ts
@@ -1,0 +1,4 @@
+// Minimal re-export for evaluation — only the types needed by sample files
+export type {
+  SearchResult,
+} from "./types";

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -1,0 +1,227 @@
+/**
+ * types.ts - Vector database interfaces and types
+ *
+ * What this file does:
+ * Defines the interfaces that the rest of the system uses to interact with
+ * the vector database. This is the abstraction layer — PRDs #25 and #26
+ * import from here and never touch Chroma (or any other backend) directly.
+ *
+ * Why an abstraction layer?
+ * The KubeCon demo shows both Chroma and Qdrant as vector database options.
+ * By coding against interfaces, the data loading pipelines work with either
+ * backend. Swap the implementation, keep the same pipeline code.
+ *
+ * Key concepts:
+ * - VectorStore: The main interface for storing and searching documents
+ * - EmbeddingFunction: Turns text into numbers (vectors) for similarity search
+ * - VectorDocument: A document to store (text + metadata)
+ * - SearchResult: A document found by similarity search (text + metadata + score)
+ */
+
+/**
+ * A function that converts text into embedding vectors.
+ *
+ * What are embeddings?
+ * When you embed text, you turn it into an array of numbers (a "vector") that
+ * captures the meaning of the text. Similar texts produce similar vectors.
+ * This is what makes semantic search possible — "find resources related to
+ * databases" works because the query vector is close to vectors for database
+ * resources, even if the exact words differ.
+ *
+ * Why an interface?
+ * Different embedding models (Voyage AI, OpenAI, local models) all do the
+ * same thing — text in, numbers out. The interface lets us swap models without
+ * changing any vector store or pipeline code.
+ */
+export interface EmbeddingFunction {
+  /**
+   * Converts an array of text strings into embedding vectors.
+   *
+   * @param texts - The strings to embed (e.g., document descriptions)
+   * @returns A 2D array: one vector (number[]) per input text
+   */
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+/**
+ * A document to store in the vector database.
+ *
+ * Each document has three parts:
+ * - id: A unique identifier (e.g., "apps/v1/Deployment")
+ * - text: The content to embed and search against
+ * - metadata: Structured fields for filtering (kind, apiGroup, etc.)
+ *
+ * The text gets embedded into a vector for similarity search.
+ * The metadata stays as-is for exact-match filtering (e.g., "find all CRDs").
+ */
+export interface VectorDocument {
+  /** Unique identifier for the document (used for updates and deletes) */
+  id: string;
+  /** The text content to embed — this is what semantic search matches against */
+  text: string;
+  /** Structured metadata for filtering — not embedded, used for exact queries */
+  metadata: Record<string, string | number | boolean>;
+}
+
+/**
+ * A search result returned from a similarity query.
+ *
+ * Extends VectorDocument with a similarity score so the caller can
+ * decide how relevant each result is.
+ */
+export interface SearchResult extends VectorDocument {
+  /**
+   * How similar this result is to the query.
+   *
+   * With cosine distance: 0.0 = identical, 2.0 = opposite.
+   * Lower scores mean more similar results.
+   * Chroma returns distances, not similarity scores.
+   * Set to -1 for keyword/filter-only results (no vector comparison).
+   */
+  score: number;
+}
+
+/**
+ * Options for creating a collection.
+ *
+ * A collection is like a table — it groups related documents together.
+ * We use two collections: one for capability descriptions (what resource
+ * types can do) and one for resource instances (what's running).
+ */
+export interface CollectionOptions {
+  /**
+   * The distance metric for comparing vectors.
+   *
+   * - "cosine": Standard for text embeddings. Measures angle between vectors,
+   *   ignoring magnitude. Two vectors pointing the same direction score 0.0,
+   *   regardless of length. This is what we use.
+   * - "l2": Euclidean distance. Sensitive to vector magnitude.
+   * - "ip": Inner product. Used with normalized vectors.
+   *
+   * Must be set at collection creation time — cannot be changed later.
+   */
+  distanceMetric: "cosine" | "l2" | "ip";
+}
+
+/**
+ * Options for searching a collection.
+ */
+export interface SearchOptions {
+  /** Maximum number of results to return (default: 10) */
+  nResults?: number;
+  /**
+   * Metadata filter for exact-match queries.
+   *
+   * Example: { kind: "Deployment" } only returns documents where
+   * metadata.kind === "Deployment". This narrows the search before
+   * comparing vectors, making it faster and more precise.
+   *
+   * Uses Chroma's where syntax under the hood. Simple key-value pairs
+   * do exact matching. For advanced operators ($gt, $in, etc.), pass
+   * them as nested objects per the Chroma docs.
+   */
+  where?: Record<string, unknown>;
+  /**
+   * Document content filter for substring matching.
+   *
+   * Example: { "$contains": "backup" } only returns documents whose text
+   * contains the word "backup". This filters on the stored document text,
+   * not on metadata.
+   *
+   * Used by the keyword search dimension — no embedding API call needed.
+   * Can be combined with semantic search (query + whereDocument) for
+   * ranked results within substring-matched documents.
+   */
+  whereDocument?: Record<string, unknown>;
+}
+
+/**
+ * The main interface for vector database operations.
+ *
+ * This is what PRDs #25 and #26 code against. They call store() to add
+ * documents and never need to know whether Chroma or Qdrant is behind it.
+ *
+ * The agent's search tools (M3) will call search() to find relevant resources.
+ *
+ * Usage pattern:
+ *   1. initialize() — create the collection (idempotent, safe to call twice)
+ *   2. store() — add documents (embeddings computed automatically)
+ *   3. search() — find similar documents by natural language query
+ *   4. delete() — remove documents by ID
+ */
+export interface VectorStore {
+  /**
+   * Creates a collection if it doesn't exist, or returns the existing one.
+   *
+   * Idempotent — calling this twice with the same name is safe. This matters
+   * because PRDs #25 and #26 both call initialize independently, and re-running
+   * a sync script shouldn't fail because collections already exist.
+   *
+   * @param collection - Name of the collection (e.g., "capabilities")
+   * @param options - Configuration like distance metric
+   */
+  initialize(collection: string, options: CollectionOptions): Promise<void>;
+
+  /**
+   * Stores documents in a collection.
+   *
+   * Each document's text is embedded automatically (using the configured
+   * embedding function) and stored alongside its metadata. If a document
+   * with the same ID already exists, it is updated (upsert behavior).
+   *
+   * @param collection - Which collection to store in
+   * @param documents - The documents to store
+   */
+  store(collection: string, documents: VectorDocument[]): Promise<void>;
+
+  /**
+   * Searches a collection using natural language.
+   *
+   * The query text is embedded into a vector, then compared against all
+   * stored document vectors using the collection's distance metric. Returns
+   * the closest matches, optionally filtered by metadata.
+   *
+   * @param collection - Which collection to search
+   * @param query - Natural language query (e.g., "managed database")
+   * @param options - Optional: limit results, filter by metadata
+   * @returns Matching documents sorted by similarity (best first)
+   */
+  search(
+    collection: string,
+    query: string,
+    options?: SearchOptions
+  ): Promise<SearchResult[]>;
+
+  /**
+   * Searches a collection by keyword substring matching without embeddings.
+   *
+   * Uses the vector database's document content filter (Chroma's where_document
+   * with $contains) to find documents containing the keyword. No embedding API
+   * call is made — this is fast and free.
+   *
+   * If keyword is omitted, returns documents matching only metadata filters
+   * from the options.where parameter. This supports the "filters only" path
+   * where the agent specifies kind/apiGroup/namespace without a query or keyword.
+   *
+   * Results have no similarity score (score is -1) since there's no vector
+   * comparison. Use search() instead when you need semantic ranking.
+   *
+   * @param collection - Which collection to search
+   * @param keyword - Optional substring to match against document text
+   * @param options - Optional: limit results, filter by metadata
+   * @returns Matching documents (unranked, score = -1)
+   */
+  keywordSearch(
+    collection: string,
+    keyword?: string,
+    options?: SearchOptions
+  ): Promise<SearchResult[]>;
+
+  /**
+   * Deletes documents from a collection by ID.
+   *
+   * @param collection - Which collection to delete from
+   * @param ids - IDs of documents to remove
+   */
+  delete(collection: string, ids: string[]): Promise<void>;
+}

--- a/telemetry-agent.yaml
+++ b/telemetry-agent.yaml
@@ -1,0 +1,4 @@
+# telemetry-agent.yaml — manually created for evaluation run-1
+# (telemetry-agent init has no wired handler)
+schemaPath: ./telemetry/registry
+sdkInitFile: ./src/telemetry/setup.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- First-draft telemetry agent ran against 7 TypeScript sample files via MCP interface
- 7 spans added across 4 files (discovery.ts, inference.ts, format-results.ts, kubectl-get.ts)
- 3 files correctly skipped: types.ts (type-only), tracing/index.ts (infrastructure), utils/kubectl.ts (already instrumented)
- OTel dependencies added: `@opentelemetry/api` (peer), `@opentelemetry/sdk-node`, SDK init file
- TS sample files copied from cluster-whisperer with stub modules for import resolution

## Context

This PR is an **evaluation artifact** — the instrumented code was produced by an AI telemetry agent as part of [telemetry-agent-research PRD #2](https://github.com/wiggitywhitney/telemetry-agent-research/issues/2). The purpose is to capture CodeRabbit's review of AI-generated OTel instrumentation as an evaluation signal.

The agent added standard OpenTelemetry patterns: `tracer.startActiveSpan()`, `span.setAttribute()`, `span.recordException()`, `span.setStatus()`, `span.end()` with try/catch/finally error handling. No schema extensions were created (all attributes are custom).

## Test plan

- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] Existing tests pass (320 tests, 89 suites)
- [ ] CodeRabbit reviews instrumentation quality (this is the evaluation signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kubernetes resource discovery pipeline to identify API resources and Custom Resource Definitions
  * Integrated AI-powered capability inference for discovered resources
  * Added vector store abstraction layer for semantic search capabilities
  * New kubectl integration tools for resource querying

* **Chores**
  * Updated dependencies including OpenTelemetry instrumentation framework
  * Added TypeScript build configuration
  * Documentation updates for evaluation target setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->