### PR TITLE
Add PRD #5: Evaluation Run-5

### DIFF
--- a/prds/5-evaluation-run-5.md
+++ b/prds/5-evaluation-run-5.md
@@ -212,7 +212,7 @@ Four-phase approach:
   1. Aggregate from `evaluation/run-5/per-file-evaluation.json`.
   2. Score each dimension with per-rule evidence AND per-file instance counts (files passing/failing each rule).
   3. Apply schema coverage split scoring as standard (SCH-002 split by covered/uncovered files).
-  4. Classify each failure: persistent / new regression / genuine new finding / methodology-driven.
+  4. Classify each failure as persistent, new regression, genuine new finding, or methodology-driven.
   5. Apply systemic bug classification where applicable (one root cause → one finding, N affected instances).
   6. **Single canonical score** using per-file evaluation + schema coverage split. Provide methodology-adjusted comparison ONLY for backward compatibility with runs 2-4.
   7. Emit as `evaluation/run-5/rubric-scores.json` (canonical) and render `evaluation/run-5/rubric-scores.md`.


### PR DESCRIPTION
## Summary
- Adds PRD #5 for evaluation run-5, encoding all lessons from run-4
- Key focus: verify schema evolution fix, validation pipeline, and 3 high-priority agent behavior fixes
- Establishes per-file evaluation as canonical methodology
- Formalizes recommendation-document handoff process

## Context
Run-4 evaluation is complete on branch `feature/prd-4-evaluation-run-4`. This PRD encodes the 13 findings, methodology improvements, and process lessons from that evaluation into the next run's structure. Created on a separate branch because evaluation branches are never merged to main.

## Test plan
- [ ] PRD structure follows established pattern (matches PRDs #2-4)
- [ ] All run-4 lessons from `lessons-for-prd5.md` are encoded in milestones
- [ ] Score baselines match run-4 canonical artifacts
- [ ] Handoff process documented as formal milestone
- [ ] Evaluation branch lifecycle documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Run‑5 planning document covering goals, context, Run‑4 baselines, a four‑phase solution overview, success criteria, milestones, evaluation architecture, instrumentation and verification workflows, pre‑run checks, scoring and evidence standards, systemic bug classification, handoff procedures, decision logs, risk mitigations, and artifact generation guidance. No user‑facing features or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->