### PR TITLE
docs(prd-14): close PRD #14 — orbweaver CI workflow

### DIFF
--- a/prds/done/14-orbweaver-ci-workflow.md
+++ b/prds/done/14-orbweaver-ci-workflow.md
@@ -1,7 +1,8 @@
 # PRD #14: Orbweaver CI Workflow
 
-**Status:** In Progress
+**Status:** Complete
 **Created:** 2026-03-18
+**Completed:** 2026-03-19
 **GitHub Issue:** #14
 **Priority:** High
 
@@ -71,7 +72,7 @@ workflow_dispatch (manual trigger)
 ## Milestones
 
 - [x] **Workflow file created and valid** — `.github/workflows/orbweaver-instrument.yml` passes `actionlint` and can be dispatched. Includes: dual checkout, Node 24 setup, orbweaver `npm ci`, Weaver CLI install, config rename step.
-- [ ] **CLI invocation runs successfully** — `spiny-orb instrument --yes --no-pr --output json src/` executes in CI, produces JSON output, and exits. Full 30-file run completes within timeout.
+- [ ] **CLI invocation runs successfully** — `spiny-orb instrument --yes --no-pr --output json src/` executes in CI, produces JSON output, and exits. Full 30-file run completes within timeout. *(Pending first workflow dispatch — code merged via PR #15, workflow not yet triggered)*
 - [x] **Result parsing and job summary** — JSON output is parsed into a markdown table written to `$GITHUB_STEP_SUMMARY`. Table includes: file path, status, spans added, schema extensions, error progression, token usage. `::warning` annotations emitted for advisories.
 - [x] **Artifact upload** — Full JSON result uploaded as a build artifact with 30-day retention.
 - [x] **PR creation with instrumented code** — Workflow commits changes to a `orb/instrument-YYYYMMDD-HHMMSS` branch and creates a PR with a structured summary derived from the JSON result.


### PR DESCRIPTION
## Description

**What does this PR do?**
Archives PRD #14 to `prds/done/` and marks it as complete. The orbweaver CI workflow was implemented and merged in PR #15.

**Why is this change needed?**
PRD #14 implementation is complete — all code milestones are done. The CLI invocation milestone is pending first manual workflow dispatch but is not a code blocker.

## Related Issues

- Closes #14

## Type of Change

- [x] 📚 Documentation update

## Testing Checklist

- [x] All existing tests pass locally
- N/A — documentation-only change (PRD archival)

## Documentation Checklist

- [x] Documentation updated (if applicable)

## Security Checklist

- [x] No secrets or credentials committed

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] Any dependent changes have been merged and published
- [x] PR title follows Conventional Commits format

## Additional Context

**Reviewer Notes:**
PRD file moved from `prds/` to `prds/done/`, status updated to Complete with completion date. One milestone (CLI invocation) noted as pending first workflow dispatch — the workflow code itself is merged and ready.

**Follow-up Work:**
- Dispatch the orbweaver-instrument workflow to validate the CLI invocation milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the orbweaver CI workflow PRD status to complete with a completion timestamp.
  * Clarified milestone status regarding workflow dispatch and execution readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->