### PR TITLE
docs(prd-6): link GitHub issue #17 to PRD file

### DIFF
--- a/prds/6-evaluation-run-6.md
+++ b/prds/6-evaluation-run-6.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Created:** 2026-03-17
-**GitHub Issue:** TBD
+**GitHub Issue:** #17
 **Depends on:** PRD #5 (run-5 complete, 22 findings documented, actionable fix output delivered to orbweaver)
 
 ---


### PR DESCRIPTION
## Summary
- Created GitHub issue #17 with `PRD` label for PRD #6 (Evaluation Run-6)
- Updated `prds/6-evaluation-run-6.md` to reference issue #17 (was `TBD`)

## Test plan
- [x] Verify `/prds-get` now returns PRD #6 via issue #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references for evaluation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->