### PR TITLE
docs(prd-55): prepare run-14 for execution

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,19 +3,20 @@
 Execution order within each tier matters. Items are listed in dependency order — complete earlier items before starting later ones. See `docs/language-extension-plan.md` for the full dependency chain (Steps 1-7).
 
 ## Short-term
-- JS evaluation run-13: NDS-003 truthy fix verification (PRD #37)
+- ~~JS evaluation run-13: NDS-003 truthy fix verification (PRD #37)~~ ✅ Complete
+- JS evaluation run-14: commit-story-v2 baseline with LLM judge + TS provider (PRD #55) — waiting on spiny-orb: LLM judge (PRD #431) + TypeScript provider (#372) merging to main
 
 ## Medium-term (in order)
-1. Repo generalization (PRD #43)
+1. ~~Repo generalization (PRD #43)~~ ✅ Complete
 2. ~~Source cleanup: remove commit-story source code from eval repo (PRD #47)~~ ✅ Complete
 3. ~~IS integration: scoring script, OTel Collector config, Type D template update (PRD #44)~~ ✅ Complete
-4. Research spike: eval target criteria — redo scorecard + find 12 candidates (PRD #45) — no dependency on #43/#44
-5. JavaScript eval setup + Run-1: target selection from 3 candidates (PRD #53) — depends on #45; JS provider already exists
-6. TypeScript eval setup + Run-1: target selection from 3 candidates (PRD #50) — depends on #45 + TS provider landing
+4. ~~Research spike: eval target criteria — redo scorecard + find 12 candidates (PRD #45)~~ ✅ Complete
+5. TypeScript eval setup + Run-1: target selection from 3 candidates (PRD #50) — TS provider landing in spiny-orb (in progress)
+6. JavaScript eval setup + Run-1: target selection from 3 candidates (PRD #53) — JS provider already exists; sequenced after TypeScript eval
 
 ## Post-run-14 (unblocked, sequenced after run-14)
 - Save all eval run artifacts to main with per-target run log (PRD #57) — backfill runs 2–14, wire into Type D template
 
 ## Long-term (blocked by language providers)
-7. Python eval setup + Run-1: target selection from 3 candidates (PRD #51) — depends on #45 + Python provider landing
-8. Go eval setup + Run-1: target selection from 3 candidates (PRD #52) — depends on #45 + Go provider landing
+7. Python eval setup + Run-1: target selection from 3 candidates (PRD #51) — depends on Python provider landing
+8. Go eval setup + Run-1: target selection from 3 candidates (PRD #52) — depends on Go provider landing

--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -124,7 +124,7 @@ The methodology and artifacts belong together because the methodology evolves fr
 spinybacked-orbweaver-eval/
   evaluation/
     commit-story-v2/          ← move current run-1 through run-N here
-      run-1/ ... run-13/
+      run-1/ ... run-N/
     cluster-whisperer/        ← TypeScript target (if validated)
       run-1/
     k8s-vectordb-sync/        ← Go target (if validated)
@@ -146,7 +146,7 @@ PRD numbering stays sequential (GitHub issue numbers). PRD titles include the ta
 - Update PRD titles and prior art references to include target names
 - Create `docs/ROADMAP.md`
 - Document "how to add a new language eval" as a rules/CLAUDE.md entry
-- Establish PRD template files for Type C and Type D in `docs/templates/` so future agents have a canonical starting point. Until `docs/templates/` exists, use the most recent JS eval run PRD (currently `prds/37-evaluation-run-13.md`) as the style reference for Type D, and this document's Type C description as the structure reference for Type C.
+- Establish PRD template files for Type C and Type D in `docs/templates/` so future agents have a canonical starting point. Style references live in `docs/templates/eval-run-style-reference/`. Use the most recent JS eval run PRD (currently `prds/55-evaluation-run-14.md`) as the milestone structure reference for Type D, and this document's Type C description as the structure reference for Type C.
 
 ---
 
@@ -299,9 +299,9 @@ Prerequisites: none — can run in parallel with or after Steps 1–2. Produces 
 **Output**: writes findings to `docs/research/eval-target-criteria.md`. Steps 5–7 cannot proceed until this file exists.
 *Accomplishes: the system has an evidence-based scorecard for choosing targets. No longer guessing what "good" looks like.*
 
-**Step 4 — JS evaluation run-13** *(PRD #37, already created)*
-Gate: NDS-003 truthy-check fix merges in spiny-orb. Spawns an indefinite run chain: run-13 findings → run-14 PRD drafted at completion → run-14 picks up when fixes land → run-14 drafts run-15 → and so on.
-*Accomplishes: verifies the NDS-003 fix resolved run-12's regression. First run on the new repo structure after Step 1.*
+**Step 4 — JS evaluation run chain** *(run-13 complete; run-14 current — PRD #55)*
+Run-13 verified the NDS-003 fix (PRD #37, complete). Run-14 (PRD #55) is the current run — gates on LLM judge (spiny-orb PRD #431) and TypeScript provider (#372) merging to main. The run chain continues indefinitely: each run's findings → next run PRD drafted at completion.
+*Accomplishes: ongoing JS quality baseline on commit-story-v2; each run verifies spiny-orb fixes and surfaces new improvement opportunities.*
 
 **Step 5 — TypeScript eval setup + Run-1**
 Gates: TypeScript language provider lands in spiny-orb AND `docs/research/eval-target-criteria.md` exists with a TypeScript verdict. Read that file first to confirm the validated target before forking anything. Spawns an indefinite TypeScript run chain (same pattern as Step 4).

--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -226,7 +226,7 @@ When spiny-orb adds a new language provider, add it to the eval framework in two
 
 ## Score Projection Methodology
 
-All run score projections use a **50% discount** to account for LLM variation: the expected score in any run is 50% between the ideal (all fixes landed, best case) and the worst case (all failures recur). "After 50% discount" means the midpoint between these two outcomes. This calibrates expectations without over-relying on whether a specific fix landed cleanly.
+Score projections use three named scenarios: **Conservative** (fixes land but LLM variation causes some failures), **Target** (all fixes land cleanly), and **Stretch** (all fixes plus cost reduction). Each scenario states its assumptions explicitly. Do not add an "after discount" row — the scenario labels carry that meaning.
 
 ---
 

--- a/docs/templates/eval-run-style-reference/actionable-fix-output.md
+++ b/docs/templates/eval-run-style-reference/actionable-fix-output.md
@@ -188,34 +188,28 @@ The key constraint: if the `if` body contains ONLY `span.*` calls, it is an inst
 
 ## §7. Score Projections for Run-13
 
-**Note on "50% discount"**: Evaluation methodology applies a 50% discount to score projections to account for LLM variation — meaning the expected score in any run is 50% between the ideal (all fixes landed, best case) and the worst case (all failures recur). Projections below show both the raw expected score and the discounted range.
-
-### Minimum (no fixes — P1/P2 not landed)
+### Conservative (fixes land but LLM variation causes some failures)
 
 - **Quality**: 23/25 (92%) — same failures likely to recur (LLM variation + NDS-003 truthy gap still active)
-- **Files**: 12-13 (summary-detector.js may fully commit if API load is normal)
+- **Files**: 11-13 (summary-detector.js may fully commit if API load is normal)
 - **Push/PR**: YES (fine-grained PAT stable)
-- **After 50% discount**: 22-23/25, 11-13 files
 
 ### Target (P1 fix: NDS-003 truthy-check allowlist)
 
 - **Quality**: 25/25 (100%) — CDQ-007 failure resolved, attribute completeness improves
 - **Files**: 13 (summary-manager.js may improve with correct COV-004 guidance)
 - **Cost**: Unclear — depends on journal-graph.js attempt count
-- **After 50% discount**: 24-25/25, 12-13 files
 
 ### Target + P2 (NDS-003 truthy fix + COV-004 guidance)
 
 - **Quality**: 25/25 (100%) — both run-12 failures addressed
 - **Files**: 13
-- **After 50% discount**: 25/25, 13 files, PR likely
 
 ### Stretch (all fixes + cost reduction)
 
 - **Quality**: 25/25, full attribute coverage
 - **Files**: 13
 - **Cost**: ≤$4.00 if journal-graph.js returns to 2 attempts
-- **After 50% discount**: 25/25, 13 files
 
 ---
 

--- a/docs/templates/eval-run-style-reference/baseline-comparison.md
+++ b/docs/templates/eval-run-style-reference/baseline-comparison.md
@@ -70,14 +70,11 @@ PR #61 created. Token-swap mechanism continues to work. Fine-grained PAT stable.
 
 | Scenario | Projected | Actual | Verdict |
 |----------|-----------|--------|---------|
-| Minimum (no fixes) | 25/25, 13 files, PR YES | 23/25, 12+1p files, PR YES | **Not met** — 2 new failures |
+| Conservative (no fixes) | 25/25, 13 files, PR YES | 23/25, 12+1p files, PR YES | **Not met** — 2 new failures |
 | Target (NDS-003 truthy fix) | 25/25, 13 files, ≤$4.00 | 23/25, 12+1p, $5.19 | **Not met** |
 | Stretch (all fixes) | 25/25, 13 files, ~$3.50 | 23/25, 12+1p, $5.19 | **Not met** |
-| After 50% discount | 24-25/25, 12-13 files, PR likely | 23/25, 12+1p, PR YES | **Partially met** |
 
-The minimum projection assumed "no known quality failures" and that NDS-003 truthy gap was the only outstanding issue. Run-12 found two new failures: COV-004 (span omission strategy) and CDQ-007 (unconditional setAttribute). Both are LLM variation outcomes — the agent made defensible but rubric-noncompliant decisions under the NDS-003 constraint.
-
-The 50% discount projection partially holds: quality was 92% (within range), files were 12+1p (within range), and PR was created. The quality shortfall is 2pp below the 50% discount floor.
+The conservative projection assumed "no known quality failures" and that NDS-003 truthy gap was the only outstanding issue. Run-12 found two new failures: COV-004 (span omission strategy) and CDQ-007 (unconditional setAttribute). Both are LLM variation outcomes — the agent made defensible but rubric-noncompliant decisions under the NDS-003 constraint.
 
 ---
 

--- a/docs/templates/eval-run-style-reference/baseline-comparison.md
+++ b/docs/templates/eval-run-style-reference/baseline-comparison.md
@@ -68,13 +68,17 @@ PR #61 created. Token-swap mechanism continues to work. Fine-grained PAT stable.
 
 **Run-11 actionable fix output projected for run-12:**
 
+<!-- Note: this example predates the Conservative/Target/Stretch naming convention.
+     Current methodology uses: Conservative (fixes land, LLM varies), Target (all fixes land cleanly), Stretch (fixes + cost reduction).
+     The "Minimum" label below reflects run-12's original projection terminology. -->
+
 | Scenario | Projected | Actual | Verdict |
 |----------|-----------|--------|---------|
-| Conservative (no fixes) | 25/25, 13 files, PR YES | 23/25, 12+1p files, PR YES | **Not met** — 2 new failures |
+| Minimum (no fixes land) | 25/25, 13 files, PR YES | 23/25, 12+1p files, PR YES | **Not met** — 2 new failures |
 | Target (NDS-003 truthy fix) | 25/25, 13 files, ≤$4.00 | 23/25, 12+1p, $5.19 | **Not met** |
 | Stretch (all fixes) | 25/25, 13 files, ~$3.50 | 23/25, 12+1p, $5.19 | **Not met** |
 
-The conservative projection assumed "no known quality failures" and that NDS-003 truthy gap was the only outstanding issue. Run-12 found two new failures: COV-004 (span omission strategy) and CDQ-007 (unconditional setAttribute). Both are LLM variation outcomes — the agent made defensible but rubric-noncompliant decisions under the NDS-003 constraint.
+The minimum projection assumed "no known quality failures" and that NDS-003 truthy gap was the only outstanding issue. Run-12 found two new failures: COV-004 (span omission strategy) and CDQ-007 (unconditional setAttribute). Both are LLM variation outcomes — the agent made defensible but rubric-noncompliant decisions under the NDS-003 constraint.
 
 ---
 

--- a/prds/55-evaluation-run-14.md
+++ b/prds/55-evaluation-run-14.md
@@ -1,6 +1,6 @@
 # PRD #14: JS Evaluation Run-14: commit-story-v2 — Smart Rollback + Type-Safety Verification
 
-**Status:** Draft
+**Status:** Ready
 **Created:** 2026-04-12
 **GitHub Issue:** #55
 **Depends on:** PRD #13 (run-13 complete, 3 findings documented, actionable fix output delivered to spiny-orb team)
@@ -58,7 +58,7 @@ Verify that three spiny-orb fixes land cleanly in run-14:
 | journal-graph.js summaryNode NDS-003 | RUN11-5 | 3 runs | P1 fix in RUN13-3 |
 | journal-graph.js 3 attempts | RUN12-4 | 2 runs | LLM variation, unknown root cause |
 | Cost above $4.00 | RUN11-4 | 3 runs | Regressed to ~$6.41 in run-13 |
-| Advisory contradiction rate | RUN11-1 | 3 runs | 67% in run-13 (worse) |
+| Advisory contradiction rate | RUN11-1 | 3 runs | SCH-004 fix landed (#440 closed) — run-14 verifies |
 | COV-004 on summary-manager.js | RUN12-1 | Unverified | Fix landed (PR #398) but file rolled back in run-13 |
 | RUN7-7 span count self-report | Run-7 | 8 runs | Structurally unchanged |
 | CJS require() in ESM projects | Run-2 | 13 runs | Open spec gap, not triggered |
@@ -120,15 +120,17 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
 - [ ] **Pre-run verification** — Verify spiny-orb fixes and validate run prerequisites:
   1. **Handoff triage review**: Read the spiny-orb team's triage of `evaluation/commit-story-v2/run-13/actionable-fix-output.md`. Check which findings were filed as issues.
-  2. **Smart checkpoint rollback fix** (P1 — critical): Verify RUN13-1 is merged. Check that checkpoint failures now parse the test stack trace and roll back only the file(s) named in the failing test output, not the full window.
-  3. **Type-safety setAttribute guidance** (P1 — critical): Verify RUN13-2 is merged. Check that the agent instrumentation prompt includes guidance to use `!= null` over `!== undefined`, and `new Date(value).toISOString()` for timestamp fields.
-  4. **summaryNode NDS-003 fix** (P1): Verify RUN13-3 is merged. Check that either the NDS-003 allowlist or the agent prompt addresses template literal modification in summaryNode.
-  5. **Target repo readiness** (commit-story-v2): Verify on `main`, clean working tree, spiny-orb.yaml and semconv/ exist. **Before switching to main, check for uncommitted artifacts on the current instrument branch** (run `git status` in commit-story-v2) and commit any to that branch before switching.
-  6. **Push auth stability check**: Verify token still works (dry-run push).
-  7. **File inventory**: Count .js files in commit-story-v2's `src/` directory.
-  8. Rebuild spiny-orb from **current branch** (not necessarily main — rebuild from whatever branch it's on).
-  9. Record version and findings status.
-  10. Append observations to `evaluation/commit-story-v2/run-14/lessons-for-prd15.md`.
+  2. **Smart checkpoint rollback fix** (P1 — critical, #437 + #447 confirmed closed): Verify both issues merged. #437 — rollback parses the test stack trace and reverts only the failing file, not the full window. #447 — schema extensions from reverted files are cleaned up.
+  3. **Type-safety setAttribute guidance** (P1 — critical, #435 + #436 confirmed closed): Verify both issues merged. #435 — prompt guidance for `!= null` over `!== undefined`. #436 — prompt guidance against assuming string type when calling string methods on attribute values.
+  4. **summaryNode NDS-003 fix** (P1, #438 confirmed closed): Verify merged. Check that either the NDS-003 allowlist or the agent prompt addresses template literal modification in summaryNode.
+  5. **SCH-004 advisory contradiction fix** (#440 confirmed closed): Verify merged. Run-13 had 67% false-positive rate on SCH-004. This is the first run where the fix should be reflected in advisory findings.
+  6. **SCH-005 (new rule — LLM judge PRD #431)**: Verify SCH-005 (registry span deduplication via LLM judge) is merged to spiny-orb main. This is an advisory non-blocking rule. Advisory findings referencing SCH-005 in run-14 are expected and desirable — first-run signal, not a regression.
+  7. **Target repo readiness** (commit-story-v2): Verify on `main`, clean working tree, spiny-orb.yaml and semconv/ exist. **Before switching to main, check for uncommitted artifacts on the current instrument branch** (run `git status` in commit-story-v2) and commit any to that branch before switching.
+  8. **Push auth stability check**: Verify token still works (dry-run push).
+  9. **File inventory**: Count .js files in commit-story-v2's `src/` directory.
+  10. Rebuild spiny-orb from **main** (LLM judge and all prior fixes will be on main at run time).
+  11. Record version and findings status.
+  12. Append observations to `evaluation/commit-story-v2/run-14/lessons-for-prd15.md`.
 
 - [ ] **Evaluation run-14** — Whitney runs `spiny-orb instrument` in her own terminal. **Do NOT run the command yourself.** AI role in this milestone: (1) confirm readiness with Whitney, (2) once Whitney provides the log output, save it to `evaluation/commit-story-v2/run-14/spiny-orb-output.log` and write `evaluation/commit-story-v2/run-14/run-summary.md`.
 
@@ -181,18 +183,20 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
 **Note on "50% discount"**: Projections discount 50% toward worst case to account for LLM variation.
 
-### Minimum (no fixes land)
+All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. The "no fixes land" floor no longer applies — projections start from the assumption that smart rollback and type-safety guidance are active.
 
-- **Quality**: 25/25 (100%) — checkpoint catches errors before they commit
-- **Files**: 7-10 — checkpoint cascade continues without smart rollback
-- **After 50% discount**: 25/25, 7-9 files
+### Conservative (fixes land but LLM variation causes some failures)
 
-### Target (all 3 P1 fixes land)
+- **Quality**: 25/25 (100%) — checkpoint still catches errors before they commit
+- **Files**: 10-11 — smart rollback prevents cascade; some files still fail on first attempt
+- **After 50% discount**: 25/25, 10-11 files
+
+### Target (all fixes land cleanly)
 
 - **Quality**: 25/25 (100%)
-- **Files**: 13 — smart rollback saves cascade victims; summaryNode commits
+- **Files**: 13 — smart rollback saves cascade victims; summaryNode commits for the first time
 - **Cost**: ~$3-4 — sunk cost eliminated with smart rollback
-- **After 50% discount**: 25/25, 10-13 files, cost ~$4-5
+- **After 50% discount**: 25/25, 11-13 files, cost ~$4-5
 
 ### Stretch (all fixes + cost reduction)
 

--- a/prds/55-evaluation-run-14.md
+++ b/prds/55-evaluation-run-14.md
@@ -189,7 +189,7 @@ All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. The "no fixes 
 
 - **Quality**: 25/25 (100%) — checkpoint still catches errors before they commit
 - **Files**: 10-11 — smart rollback prevents cascade; some files still fail on first attempt
-- **After 50% discount**: 25/25, 10-11 files
+- **After 50% discount**: 25/25, 9-11 files
 
 ### Target (all fixes land cleanly)
 

--- a/prds/55-evaluation-run-14.md
+++ b/prds/55-evaluation-run-14.md
@@ -58,7 +58,7 @@ Verify that three spiny-orb fixes land cleanly in run-14:
 | journal-graph.js summaryNode NDS-003 | RUN11-5 | 3 runs | P1 fix in RUN13-3 |
 | journal-graph.js 3 attempts | RUN12-4 | 2 runs | LLM variation, unknown root cause |
 | Cost above $4.00 | RUN11-4 | 3 runs | Regressed to ~$6.41 in run-13 |
-| Advisory contradiction rate | RUN11-1 | 3 runs | SCH-004 fix landed (#440 closed) — run-14 verifies |
+| Advisory contradiction rate | RUN11-1 | 3 runs | SCH-004 fix landed (#440 closed) — verification pending in run-14 |
 | COV-004 on summary-manager.js | RUN12-1 | Unverified | Fix landed (PR #398) but file rolled back in run-13 |
 | RUN7-7 span count self-report | Run-7 | 8 runs | Structurally unchanged |
 | CJS require() in ESM projects | Run-2 | 13 runs | Open spec gap, not triggered |
@@ -189,7 +189,8 @@ All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. The "no fixes 
 
 - **Quality**: 25/25 (100%) — checkpoint still catches errors before they commit
 - **Files**: 10-11 — smart rollback prevents cascade; some files still fail on first attempt
-- **After 50% discount**: 25/25, 9-11 files
+- **Cost**: ~$4-6 — some retry cost remains without perfect LLM compliance
+- **After 50% discount**: 25/25, 9-11 files, cost ~$5-6
 
 ### Target (all fixes land cleanly)
 

--- a/prds/55-evaluation-run-14.md
+++ b/prds/55-evaluation-run-14.md
@@ -181,7 +181,7 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
 ## Score Projections for Run-14
 
-All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. Projections start from the assumption that smart rollback and type-safety guidance are active.
+All P1 fixes (#435, #436, #437, #438, #447) are reported closed. Projections start from the assumption that smart rollback and type-safety guidance are active.
 
 ### Conservative (fixes land but LLM variation causes some failures)
 

--- a/prds/55-evaluation-run-14.md
+++ b/prds/55-evaluation-run-14.md
@@ -181,27 +181,22 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
 ## Score Projections for Run-14
 
-**Note on "50% discount"**: Projections discount 50% toward worst case to account for LLM variation.
-
-All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. The "no fixes land" floor no longer applies — projections start from the assumption that smart rollback and type-safety guidance are active.
+All P1 fixes (#435, #436, #437, #438, #447) are confirmed closed. Projections start from the assumption that smart rollback and type-safety guidance are active.
 
 ### Conservative (fixes land but LLM variation causes some failures)
 
 - **Quality**: 25/25 (100%) — checkpoint still catches errors before they commit
 - **Files**: 10-11 — smart rollback prevents cascade; some files still fail on first attempt
 - **Cost**: ~$4-6 — some retry cost remains without perfect LLM compliance
-- **After 50% discount**: 25/25, 9-11 files, cost ~$5-6
 
 ### Target (all fixes land cleanly)
 
 - **Quality**: 25/25 (100%)
 - **Files**: 13 — smart rollback saves cascade victims; summaryNode commits for the first time
 - **Cost**: ~$3-4 — sunk cost eliminated with smart rollback
-- **After 50% discount**: 25/25, 11-13 files, cost ~$4-5
 
 ### Stretch (all fixes + cost reduction)
 
 - **Quality**: 25/25, full attribute coverage
 - **Files**: 13+
 - **Cost**: ≤$4.00 if journal-graph.js returns to 2 attempts
-- **After 50% discount**: 25/25, 12-13 files


### PR DESCRIPTION
## Summary

- Reopened issue #55 and updated PRD #55 to reflect current state before run-14 executes
- Pre-run verification updated: confirmed-closed issues (#435–#438, #440, #447) noted inline; SCH-005 check added (LLM judge, first appearance expected); steps renumbered; rebuild instruction corrected to use `main`
- Unresolved items table: advisory contradiction rate row updated (#440 closed)
- Score projections: stale "no fixes land" minimum replaced with "conservative" baseline reflecting confirmed fix landing

## Test plan

- [ ] PRD reads cleanly as an AI agent instruction
- [ ] Pre-run verification steps are accurate and complete
- [ ] Merge to main so `/prd-start` can pick up issue #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked the evaluation plan as Ready after final review.
  * Updated unresolved-items to reflect a merged fix pending verification in run‑14.
  * Expanded the pre-run verification checklist with explicit paired confirmations, added registry deduplication verification, changed the rebuild instruction to "rebuild from main," and renumbered steps.
  * Reworked score projections into Conservative / Target / Stretch scenarios and removed the prior "50% discount" representation; templates adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->