### PR TITLE
docs: prevent eval branch loss — push immediately, never delete

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,3 +95,13 @@ Use the immediately preceding eval run PRD as the structural model. The **first 
 Include both user-facing checkpoints (Findings Discussion and Handoff pause) in the milestone structure — exact wording is in the plan document under "Two User-Facing Checkpoints."
 
 See `docs/language-extension-plan.md` for full context: PRD taxonomy, language candidate table, score projection methodology, and process requirements.
+
+## Branch Safety — Never Orphan Commits
+
+Before deleting any local branch (`git branch -d` or especially `-D`), verify its commits exist on origin. Run:
+
+```bash
+git log --oneline <branch> ^origin/main ^origin/<branch>
+```
+
+If the output is non-empty, the branch has commits that exist nowhere else — push first, then delete. This applies especially to eval branches, which hold the canonical run artifacts until PRD #57 backfill lands. Do not assume `gh pr merge --delete-branch` handled cleanup for branches whose PRs didn't merge (eval branches never merge per convention, so their cleanup is manual and must preserve the remote).

--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -98,7 +98,7 @@ Type D PRDs form the recurring evaluation chain for each language/target.
 
 ### Eval Branch Convention (all evaluation PRDs)
 
-Evaluation feature branches (`feature/prd-N-evaluation-run-N`) **never merge to main and never get deleted**. PRs exist for CodeRabbit review only. When `/prd-done` runs at completion, close the issue without merging or deleting the eval branch. This applies to every Type D PRD.
+All eval execution branches — Type D recurring runs (`feature/prd-N-evaluation-run-N`) and Type C setup branches (`feature/prd-N-LANG-eval-setup`) — **never merge to main and never get deleted**. PRs exist for CodeRabbit review only. When `/prd-done` runs at completion, close the issue without merging or deleting the eval branch. This applies to every Type C and Type D PRD.
 
 **The branch is the canonical source for eval artifacts** until PRD #57's backfill lands them on main. Deleting the branch — even locally — risks orphaning commits that exist nowhere else. Before running any `git branch -D` or `git push origin --delete` on an eval branch, confirm the artifacts are on main first.
 

--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -78,7 +78,7 @@ Note: update `run-N` to the current run number and `commit-story-v2` to the targ
 Identical in structure to the existing PRDs #3–13. Triggered by findings from the previous run. Follows the established milestone sequence:
 1. Collect skeleton documents
 2. Pre-run verification (verify prior findings fixed, check prerequisites)
-3. Evaluation run (Whitney runs `spiny-orb instrument` in her terminal — see exact command in Type C section above)
+3. Evaluation run (Whitney runs `spiny-orb instrument` in her terminal — see exact command in Type C section above). **After saving artifacts and committing, push the eval branch to origin immediately.** The branch holds the only copy of run artifacts until PRD #57's backfill lands — do not leave it local-only.
 4. Findings Discussion *(user-facing checkpoint 1: raw signal before analysis)*
 5. Failure deep-dives
 6. Per-file evaluation
@@ -98,7 +98,9 @@ Type D PRDs form the recurring evaluation chain for each language/target.
 
 ### Eval Branch Convention (all evaluation PRDs)
 
-Evaluation feature branches (`feature/prd-N-evaluation-run-N`) **never merge to main**. PRs exist for CodeRabbit review only. When `/prd-done` runs at completion, close the issue without merging the eval branch. This applies to every Type D PRD.
+Evaluation feature branches (`feature/prd-N-evaluation-run-N`) **never merge to main and never get deleted**. PRs exist for CodeRabbit review only. When `/prd-done` runs at completion, close the issue without merging or deleting the eval branch. This applies to every Type D PRD.
+
+**The branch is the canonical source for eval artifacts** until PRD #57's backfill lands them on main. Deleting the branch — even locally — risks orphaning commits that exist nowhere else. Before running any `git branch -D` or `git push origin --delete` on an eval branch, confirm the artifacts are on main first.
 
 ---
 

--- a/prds/50-typescript-eval-setup.md
+++ b/prds/50-typescript-eval-setup.md
@@ -115,9 +115,9 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
 - [ ] **Evaluation run-1**
 
   Whitney runs `spiny-orb instrument` in her own terminal. **Do NOT run the command yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory.
-  AI role: (1) confirm readiness, (2) save log, (3) write run-summary.md.
+  AI role: (1) confirm readiness, (2) save log, (3) write run-summary.md, (4) **push the eval branch to origin immediately** (`git push -u origin feature/prd-50-typescript-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
-  Success criteria: Log saved; run-summary.md written.
+  Success criteria: Log saved; run-summary.md written; eval branch on origin.
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 

--- a/prds/51-python-eval-setup.md
+++ b/prds/51-python-eval-setup.md
@@ -116,7 +116,7 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
 - [ ] **Evaluation run-1**
 
   Whitney runs `spiny-orb instrument`. **Do NOT run yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (Python repos may use `commitizen/`, `src/`, or the package name as the source dir).
-  AI role: confirm readiness, save log, write run-summary.md.
+  AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-51-python-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 

--- a/prds/52-go-eval-setup.md
+++ b/prds/52-go-eval-setup.md
@@ -116,6 +116,8 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
 - [ ] **Evaluation run-1**
 
   Whitney runs `spiny-orb instrument`. **Do NOT run yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (Go repos typically use `.`, `cmd/`, or `internal/` — check the forked repo's layout).
+
+  AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-52-go-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
   AI role: confirm readiness, save log, write run-summary.md.
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*

--- a/prds/52-go-eval-setup.md
+++ b/prds/52-go-eval-setup.md
@@ -118,7 +118,6 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
   Whitney runs `spiny-orb instrument`. **Do NOT run yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (Go repos typically use `.`, `cmd/`, or `internal/` — check the forked repo's layout).
 
   AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-52-go-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
-  AI role: confirm readiness, save log, write run-summary.md.
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 

--- a/prds/53-javascript-eval-setup.md
+++ b/prds/53-javascript-eval-setup.md
@@ -117,6 +117,8 @@ If this PRD proceeds past milestone 0 (i.e., a new target is selected), the feat
 
   Whitney runs `spiny-orb instrument` in her own terminal. **Do NOT run the command yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (check the forked repo's structure — it may be `src/`, `lib/`, or `.`).
 
+  AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-53-javascript-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
+
   AI role: (1) confirm readiness, (2) save log output to `evaluation/<target-name>/run-1/spiny-orb-output.log`, (3) write `evaluation/<target-name>/run-1/run-summary.md`.
 
   Success criteria: Log saved; run-summary.md written with file counts, cost, timing, push/PR status.

--- a/prds/53-javascript-eval-setup.md
+++ b/prds/53-javascript-eval-setup.md
@@ -117,9 +117,7 @@ If this PRD proceeds past milestone 0 (i.e., a new target is selected), the feat
 
   Whitney runs `spiny-orb instrument` in her own terminal. **Do NOT run the command yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (check the forked repo's structure — it may be `src/`, `lib/`, or `.`).
 
-  AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-53-javascript-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
-
-  AI role: (1) confirm readiness, (2) save log output to `evaluation/<target-name>/run-1/spiny-orb-output.log`, (3) write `evaluation/<target-name>/run-1/run-summary.md`.
+  AI role: (1) confirm readiness, (2) save log output to `evaluation/<target-name>/run-1/spiny-orb-output.log`, (3) write `evaluation/<target-name>/run-1/run-summary.md`, (4) **push the eval branch to origin immediately** (`git push -u origin feature/prd-53-javascript-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
   Success criteria: Log saved; run-summary.md written with file counts, cost, timing, push/PR status.
 

--- a/prds/61-evaluation-run-15.md
+++ b/prds/61-evaluation-run-15.md
@@ -131,6 +131,8 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
   caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument src --verbose 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-15/spiny-orb-output.log
   ```
 
+  **After saving artifacts and committing, push the eval branch to origin immediately** (`git push -u origin feature/prd-61-evaluation-run-15`). The branch holds the only copy of run-15 artifacts until PRD #57's backfill lands — do not leave it local-only.
+
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)* — After `run-summary.md` is written, before any evaluation documents are started: report to Whitney: (1) files committed / failed / partial, (2) whether any checkpoint failures occurred, (3) whether summaryNode catch block looks consistent with the other nodes (signal for RUN14-1 fix), (4) quality score if visible, (5) cost, (6) push/PR status. Keep it conversational, under 10 lines. Wait for acknowledgment before proceeding.
 
 - [ ] **Failure deep-dives** — For each failed file AND run-level failure. Includes any partial files.


### PR DESCRIPTION
## Summary

Prevents recurrence of the near-miss during PRD #55 closeout, where run-14 eval artifacts were nearly lost because the branch was deleted before being pushed to origin.

## Changes

1. **`docs/language-extension-plan.md`**
   - Type D step 3 now explicitly requires pushing the eval branch after committing artifacts
   - Eval Branch Convention extended from "never merges" to "never merges, never deletes", with the rationale that the branch is the canonical source until PRD #57 backfill lands

2. **`.claude/CLAUDE.md`**
   - New "Branch Safety — Never Orphan Commits" section with a concrete `git log <branch> ^origin/main ^origin/<branch>` check to run before any force-delete

3. **PRDs #61, #50, #51, #52, #53**
   - Each eval-run milestone now includes an explicit push instruction with the correct branch name, so agents don't rely on remembering the convention

## Test plan

- [ ] Future eval runs push the branch immediately after committing artifacts
- [ ] `git branch -D` is never invoked on an eval branch without first verifying origin has the commits
- [ ] CLAUDE.md Branch Safety section is findable via search for "orphan" or "branch safety"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified branch-safety guidance to prevent orphaned local commits and added a pre-deletion verification step.
  * Explicitly require preserving evaluation run branches remotely and pushing them immediately after saving run artifacts.
  * Expanded eval-branch policy to cover additional branch types: eval branches must not be merged or deleted until artifacts are confirmed on main.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->