### PR TITLE
docs: add --thinking flag to open eval instrument commands

### DIFF
--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -80,12 +80,12 @@ This PRD type exists exactly once per target. It is the "onboarding" for that la
 **Exact instrument command** (run from the target repo directory, update `run-N` to current run number):
 
 ```bash
-caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument src --verbose --debug-dump-dir ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-N/debug-dumps 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-N/spiny-orb-output.log
+caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument src --verbose --thinking --debug-dump-dir ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-N/debug-dumps 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-N/spiny-orb-output.log
 ```
 
 Note: update `run-N` to the current run number and `commit-story-v2` to the target repo name (e.g., `taze`, `commitizen`, `k8s-vectordb-sync`) before each run. The `src` argument is the directory to instrument — adapt if the target uses a different source directory. Create the `debug-dumps/` subdirectory before running: `mkdir -p ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/<target>/run-N/debug-dumps`.
 
-**Diagnostic protocol** (for all eval runs): Do not diagnose failures from errorProgression rule IDs alone. Check all available dimensions in `spiny-orb-output.log`: **(3) full validator error messages** (complete tsc error codes, NDS-005 block previews — in `--verbose` output since PRD #582 M8) and **(4) agent notes** (always in `--verbose`). Also check **(2) actual instrumented code** in `debug-dumps/<filename>` after any failed file. Dimensions (1) run history and (5) agent thinking are test-harness only and not available in CLI eval runs.
+**Diagnostic protocol** (for all eval runs): Do not diagnose failures from errorProgression rule IDs alone. Check all available dimensions: **(2) actual instrumented code** in `debug-dumps/<filename>` (via `--debug-dump-dir`); **(3) full validator error messages** (complete tsc error codes, NDS-005 block previews — in `--verbose` output); **(4) agent notes** (in `--verbose` output); **(5) agent thinking blocks** for failed files (in `--thinking` output — use `--verbose --thinking` together for full diagnostics). Dimension (1) run history is test-harness only and not available in CLI eval runs.
 
 ### Type D: Run-N PRD (recurring, indefinitely)
 Identical in structure to the existing PRDs #3–13. Triggered by findings from the previous run. Follows the established milestone sequence:

--- a/prds/51-python-eval-setup.md
+++ b/prds/51-python-eval-setup.md
@@ -120,7 +120,7 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
   Whitney runs `spiny-orb instrument`. **Do NOT run yourself.** Copy the command template from `docs/language-extension-plan.md` (line ~72). Replace `commit-story-v2` with the chosen target name, `run-N` with `run-1`, and `src` with the target's source directory (Python repos may use `commitizen/`, `src/`, or the package name as the source dir). Create `evaluation/<target>/run-1/debug-dumps/` before running.
   AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-51-python-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
-  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages and tsc codes (dimension 3, in `--verbose` output) and `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50.)
+  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages (dimension 3, in `--verbose` output), agent notes (dimension 4, in `--verbose` output), and agent thinking blocks for failed files (dimension 5, in `--thinking` output — use `--verbose --thinking` together). Also check `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50; `--thinking` flag added per spiny-orb #643.)
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 

--- a/prds/52-go-eval-setup.md
+++ b/prds/52-go-eval-setup.md
@@ -121,7 +121,7 @@ The feature branch for this PRD **never merges to main**. The PR exists for Code
 
   AI role: confirm readiness, save log, write run-summary.md, and **push the eval branch to origin immediately** (`git push -u origin feature/prd-52-go-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
-  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages (dimension 3, in `--verbose` output) and `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50.)
+  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages (dimension 3, in `--verbose` output), agent notes (dimension 4, in `--verbose` output), and agent thinking blocks for failed files (dimension 5, in `--thinking` output — use `--verbose --thinking` together). Also check `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50; `--thinking` flag added per spiny-orb #643.)
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 

--- a/prds/53-javascript-eval-setup.md
+++ b/prds/53-javascript-eval-setup.md
@@ -121,7 +121,7 @@ If this PRD proceeds past milestone 0 (i.e., a new target is selected), the feat
 
   AI role: (1) confirm readiness, (2) save log output to `evaluation/<target-name>/run-1/spiny-orb-output.log`, (3) write `evaluation/<target-name>/run-1/run-summary.md`, (4) **push the eval branch to origin immediately** (`git push -u origin feature/prd-53-javascript-eval-setup`) — the branch holds the only copy of run-1 artifacts until PRD #57's backfill lands.
 
-  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages (dimension 3, in `--verbose` output) and `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50.)
+  **Diagnostic protocol**: When a file fails, check `spiny-orb-output.log` for full validator error messages (dimension 3, in `--verbose` output), agent notes (dimension 4, in `--verbose` output), and agent thinking blocks for failed files (dimension 5, in `--thinking` output — use `--verbose --thinking` together). Also check `debug-dumps/<filename>` for the actual instrumented code (dimension 2, via `--debug-dump-dir`). Do not diagnose from rule IDs alone. (Per 2026-04-28 decision in PRD #50; `--thinking` flag added per spiny-orb #643.)
 
   Success criteria: Log saved; run-summary.md written with file counts, cost, timing, push/PR status.
 

--- a/prds/61-evaluation-run-15.md
+++ b/prds/61-evaluation-run-15.md
@@ -128,7 +128,7 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
   **Exact command** (run from `~/Documents/Repositories/commit-story-v2`):
   ```bash
-  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument src --verbose 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-15/spiny-orb-output.log
+  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument src --verbose --thinking 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/commit-story-v2/run-15/spiny-orb-output.log
   ```
 
   **After saving artifacts and committing, push the eval branch to origin immediately** (`git push -u origin feature/prd-61-evaluation-run-15`). The branch holds the only copy of run-15 artifacts until the "Copy artifacts to main" milestone runs — do not leave it local-only.

--- a/prds/68-evaluation-run-2-release-it.md
+++ b/prds/68-evaluation-run-2-release-it.md
@@ -117,7 +117,7 @@ The feature branch for this PRD (`feature/prd-68-evaluation-run-2-release-it`) *
 
   **Instrument command** (run from `~/Documents/Repositories/release-it/`):
   ```bash
-  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument lib --verbose 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/release-it/run-2/spiny-orb-output.log
+  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL vals exec -i -f .vals.yaml -- node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument lib --verbose --thinking 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/release-it/run-2/spiny-orb-output.log
   ```
 
   AI role: (1) confirm readiness, (2) once Whitney provides the log output, save it and write `evaluation/release-it/run-2/run-summary.md`, (3) **push the eval branch to origin immediately** — the branch holds the only copy of run artifacts until step 13 copies them to main.

--- a/prds/77-evaluation-run-3-release-it.md
+++ b/prds/77-evaluation-run-3-release-it.md
@@ -132,7 +132,7 @@ The feature branch for this PRD (`feature/prd-77-evaluation-run-3-release-it`) *
 
   **Instrument command** (run from `~/Documents/Repositories/release-it/`):
   ```bash
-  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL GIT_CONFIG_GLOBAL=/Users/whitney.lee/.config/spiny-orb-eval/gitconfig vals exec -i -f .vals.yaml -- bash -c 'GITHUB_TOKEN=$GITHUB_TOKEN_RELEASE_IT node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument lib --verbose 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/release-it/run-3/spiny-orb-output.log'
+  caffeinate -s env -u ANTHROPIC_CUSTOM_HEADERS -u ANTHROPIC_BASE_URL GIT_CONFIG_GLOBAL=/Users/whitney.lee/.config/spiny-orb-eval/gitconfig vals exec -i -f .vals.yaml -- bash -c 'GITHUB_TOKEN=$GITHUB_TOKEN_RELEASE_IT node ~/Documents/Repositories/spinybacked-orbweaver/bin/spiny-orb.js instrument lib --verbose --thinking 2>&1 | tee ~/Documents/Repositories/spinybacked-orbweaver-eval/evaluation/release-it/run-3/spiny-orb-output.log'
   ```
 
   AI role: (1) confirm readiness, (2) once Whitney provides the log output, save it and write `evaluation/release-it/run-3/run-summary.md`, (3) **push the eval branch to origin immediately** — the branch holds the only copy of run artifacts until step 13 copies them to main.


### PR DESCRIPTION
spiny-orb #643 added a dedicated `--thinking` flag. Previously, `--verbose` bundled agent thinking blocks with everything else. Now:
- `--thinking` alone: thinking blocks for failed files (compact format)
- `--verbose` alone: structured output without thinking blocks
- `--verbose --thinking`: full combined view (what eval runs should use)

This makes dimension 5 (agent thinking) available in CLI eval runs for the first time — previously test-harness only.

## Changes

- `docs/language-extension-plan.md`: instrument command template + diagnostic protocol updated
- `prds/61-evaluation-run-15.md`, `prds/68-evaluation-run-2-release-it.md`, `prds/77-evaluation-run-3-release-it.md`: instrument commands updated
- `prds/51-python-eval-setup.md`, `prds/52-go-eval-setup.md`, `prds/53-javascript-eval-setup.md`: diagnostic protocols updated

PRD #82 (`feature/prd-82-taze-evaluation-run-14`) was updated separately on its own branch.

## Checklist

- [ ] Update PROGRESS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagnostic and troubleshooting protocols across all evaluation setup guides with enhanced failure investigation procedures.
  * Enhanced instrumentation command examples with additional flags to enable expanded debugging and diagnostic output.
  * Revised instructions to guide users toward additional diagnostic sources and dimensions for more effective problem identification and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->