### PR TITLE
fix(issue-90): add service.instance.id to OTel bootstrap template and target forks

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Fixed
-- (2026-05-05) Added `service.instance.id: randomUUID()` to `resourceFromAttributes` in the eval bootstrap template (`evaluation/examples/instrumentation.js`) and in all three active target forks (release-it, commit-story-v2, taze). The attribute was absent from all bootstraps, causing RES-001 (service.instance.id absent) to fail in every IS scoring run — a 10-point miss at 100 applicable IS points. Also brought the eval template up to the full reference pattern (exporter, resource config, graceful shutdown) matching the target forks (issue #90).
+- (2026-05-05) Added `service.instance.id: randomUUID()` to `resourceFromAttributes` in the eval bootstrap template and in all three active target forks (release-it, commit-story-v2, taze). The attribute was absent from all bootstraps, causing RES-001 to fail in every IS scoring run — a 10-point miss. Also brought the eval template up to the full reference pattern (OTLP exporter, resource config, graceful shutdown) to serve as a complete starting point for future Type C eval setups.
 - (2026-04-11) Fixed stale repo name references missed during PRD #43 generalization: updated Two-Repo Workflow tables in prd-32 and prd-33 to spinybacked-orbweaver-eval, removed commit-story-v2-eval/ prefix from prd-3 run-2 path, corrected self-contradictory grep patterns in prd-43 validation section (PRD #43, CodeRabbit review)
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Fixed
+- (2026-05-05) Added `service.instance.id: randomUUID()` to `resourceFromAttributes` in the eval bootstrap template (`evaluation/examples/instrumentation.js`) and in all three active target forks (release-it, commit-story-v2, taze). The attribute was absent from all bootstraps, causing RES-001 (service.instance.id absent) to fail in every IS scoring run — a 10-point miss at 100 applicable IS points. Also brought the eval template up to the full reference pattern (exporter, resource config, graceful shutdown) matching the target forks (issue #90).
 - (2026-04-11) Fixed stale repo name references missed during PRD #43 generalization: updated Two-Repo Workflow tables in prd-32 and prd-33 to spinybacked-orbweaver-eval, removed commit-story-v2-eval/ prefix from prd-3 run-2 path, corrected self-contradictory grep patterns in prd-43 validation section (PRD #43, CodeRabbit review)
 
 ### Added

--- a/evaluation/examples/instrumentation.js
+++ b/evaluation/examples/instrumentation.js
@@ -1,28 +1,58 @@
-// ABOUTME: OpenTelemetry SDK initialization for commit-story-v2.
-// ABOUTME: Bootstraps the NodeSDK with an instrumentations array for the telemetry agent to populate.
+// ABOUTME: OTel SDK bootstrap template for eval target repos.
+// ABOUTME: Copy to target repo's examples/instrumentation.js and replace service.name placeholder.
 
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
 const instrumentations = [
   // Telemetry agent appends instrumentation entries here
 ];
 
+// Disable auto-metrics — SDK 2.x auto-instantiates a Metrics SDK.
+// For IS scoring runs: set IS_SCORING_RUN=1 to enable the metrics exporter so
+// MET rules can be evaluated.
+if (!process.env.OTEL_METRICS_EXPORTER && !process.env.IS_SCORING_RUN) {
+  process.env.OTEL_METRICS_EXPORTER = 'none';
+}
+
+const traceExporter = new OTLPTraceExporter({
+  url: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || 'http://localhost:4318/v1/traces',
+});
+
 const sdk = new NodeSDK({
+  resource: resourceFromAttributes({
+    'service.name': 'target-app', // replace with actual service name
+    'service.version': pkg.version,
+    'deployment.environment': process.env.NODE_ENV || 'development',
+    'service.instance.id': randomUUID(),
+  }),
+  // SimpleSpanProcessor exports each span immediately on span.end() — better
+  // for CLI apps where process.exit() can kill the event loop before a
+  // BatchSpanProcessor flushes.
+  spanProcessors: [new SimpleSpanProcessor(traceExporter)],
   instrumentations,
 });
 
 sdk.start();
 
-const shutdown = () => {
-  sdk.shutdown()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error('Error shutting down OTel SDK', err);
-      process.exit(1);
-    });
-};
+// Graceful shutdown — flush pending spans before exit.
+// SIGTERM uses 143 (128 + SIGTERM signal number 15).
+// SIGINT uses 130 (128 + SIGINT signal number 2).
+process.on('SIGTERM', async () => {
+  await sdk.shutdown().catch((err) => console.error('OTel SDK shutdown error:', err));
+  process.exit(143);
+});
 
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
-
-export default sdk;
+process.on('SIGINT', async () => {
+  await sdk.shutdown().catch((err) => console.error('OTel SDK shutdown error:', err));
+  process.exit(130);
+});


### PR DESCRIPTION
## Summary

- Updates `evaluation/examples/instrumentation.js` (the canonical eval bootstrap template) to include `service.instance.id: randomUUID()` in `resourceFromAttributes`
- Brings the template up to the full reference pattern used by target forks: OTLP exporter, resource config, graceful shutdown
- Target fork fixes also applied: wiggitywhitney/release-it@be7e06d (pushed to main), wiggitywhitney/taze@f16b763 (pushed to main), commit-story-v2 in PR #67

`service.instance.id` was absent from all eval target bootstraps, causing RES-001 to fail in every IS scoring run — a 10-point miss. release-it run-3 scored 90/100 and commit-story-v2 run-14 scored 80/100; both would reach 100/100 on applicable IS rules with this fix in place.

## Test plan

- [ ] Verify `evaluation/examples/instrumentation.js` includes `service.instance.id: randomUUID()`
- [ ] Confirm `randomUUID` is imported from `node:crypto`
- [ ] Next IS scoring run on any target should show RES-001 passing

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing service instance attribute that caused IS scoring runs to fail.

* **Improvements**
  * Updated instrumentation template with immediate span export, configurable exporter endpoint, explicit resource attributes, and improved startup/shutdown behavior.

* **Documentation**
  * Added progress log entry documenting the fix and template updates across target environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->