### PR TITLE
docs: add 698 live-check verification to open eval PRDs and Type D template

### DIFF
--- a/docs/language-extension-plan.md
+++ b/docs/language-extension-plan.md
@@ -90,13 +90,13 @@ Note: update `run-N` to the current run number and `commit-story-v2` to the targ
 ### Type D: Run-N PRD (recurring, indefinitely)
 Identical in structure to the existing PRDs #3–13. Triggered by findings from the previous run. Follows the established milestone sequence:
 1. Collect skeleton documents
-2. Pre-run verification (verify prior findings fixed, check prerequisites)
+2. Pre-run verification (verify prior findings fixed, check prerequisites; confirm 698 live-check is on spiny-orb main)
 3. Evaluation run (Whitney runs `spiny-orb instrument` in her terminal — see exact command in Type C section above). **After saving artifacts and committing, push the eval branch to origin immediately.** The branch holds the only copy of run artifacts until PRD #57's backfill lands — do not leave it local-only.
 3a. **Create PR for the eval branch** (`gh pr create --base main`). Leave it open — eval PRs are never merged. Title format: `eval(prd-N): <target> run-N evaluation — <quality score> quality, Q×F <score>, IS <score>/100`. The score fields are filled in after rubric scoring (step 8) and IS scoring (step 9) complete — update the PR title at that point.
-4. Findings Discussion *(user-facing checkpoint 1: raw signal before analysis)*
+4. Findings Discussion *(user-facing checkpoint 1: raw signal before analysis)* — required items: files committed/failed/partial, quality score, cost, push/PR status, live-check result (pass/advisory/fail + one-line Weaver summary, or "not triggered"), and run-specific highlights
 5. Failure deep-dives
 6. Per-file evaluation
-7. PR artifact evaluation
+7. PR artifact evaluation — include a live-check section: three-state result accuracy (pass/advisory/fail), compliance finding quality, and actionability of advisory detail
 8. Rubric scoring
 9. IS scoring run
    1. **Prerequisites**: OTel Collector running with `evaluation/is/otelcol-config.yaml` (see `evaluation/is/README.md` for install and start instructions). No metrics-exporter override needed — MET rules are marked `not_applicable` by the scorer regardless.

--- a/prds/82-taze-evaluation-run-14.md
+++ b/prds/82-taze-evaluation-run-14.md
@@ -119,6 +119,7 @@ The eval execution branch (`feature/prd-82-taze-evaluation-run-14`) **never has 
   7. **File inventory**: Count `.ts` files in `~/Documents/Repositories/taze/src/` — should be 33.
   8. Rebuild spiny-orb: `cd ~/Documents/Repositories/spinybacked-orbweaver && npm run build`
   9. Record spiny-orb SHA, Node version, and pnpm version. Append to `evaluation/taze/run-14/lessons-for-run15.md`.
+  10. **698 live-check gate**: Confirm the 698 live-check feature is on spiny-orb main. Run `git -C ~/Documents/Repositories/spinybacked-orbweaver log --oneline | head -20 | grep -i 'prd-698\|live-check'`. If present, the run will produce a three-state live-check result (pass/advisory/fail) in the PR summary and verbose log — the Findings Discussion live-check item (item 7) and PR artifact live-check section both apply. If absent, note in lessons-for-run15.md and skip those items.
 
 - [ ] **Evaluation run-14** — Whitney runs `spiny-orb instrument` in her own terminal. **Do NOT run the command yourself.** Run from `~/Documents/Repositories/taze`:
 
@@ -128,7 +129,7 @@ The eval execution branch (`feature/prd-82-taze-evaluation-run-14`) **never has 
 
   AI role: (1) create the `debug/` directory before Whitney runs; (2) confirm readiness; (3) once Whitney provides the log, save it and write `evaluation/taze/run-14/run-summary.md`. **After saving artifacts and committing, push the eval branch to origin immediately.**
 
-- [ ] **Findings Discussion** *(user-facing checkpoint 1)* — After `run-summary.md` is written, before any evaluation documents are started: report to Whitney: (1) files committed / failed / partial, (2) quality score, (3) cost, (4) push/PR status, (5) CDQ-006 violation count vs run-13 (was 8 across 5 files), (6) top 1-2 surprises. Conversational, under 10 lines. Wait for acknowledgment before proceeding.
+- [ ] **Findings Discussion** *(user-facing checkpoint 1)* — After `run-summary.md` is written, before any evaluation documents are started: report to Whitney: (1) files committed / failed / partial, (2) quality score, (3) cost, (4) push/PR status, (5) CDQ-006 violation count vs run-13 (was 8 across 5 files), (6) live-check result — pass/advisory/fail plus a one-line summary of what Weaver found (or "not triggered" if 698 was absent from the build), (7) top 1-2 surprises. Conversational, under 10 lines. Wait for acknowledgment before proceeding.
 
 - [ ] **Failure deep-dives** — For each failed or partially committed file and run-level failure.
   Produces: `evaluation/taze/run-14/failure-deep-dives.md`
@@ -138,7 +139,7 @@ The eval execution branch (`feature/prd-82-taze-evaluation-run-14`) **never has 
   Produces: `evaluation/taze/run-14/per-file-evaluation.md`
   Style reference: `docs/templates/eval-run-style-reference/per-file-evaluation.md`
 
-- [ ] **PR artifact evaluation** — Evaluate PR summary quality.
+- [ ] **PR artifact evaluation** — Evaluate PR summary quality. Include a live-check section: assess the three-state result (pass/advisory/fail), whether Weaver's compliance findings accurately reflect the telemetry produced, and whether the advisory detail is actionable. If 698 was absent from the build, note that and skip the live-check section.
   Produces: `evaluation/taze/run-14/pr-evaluation.md`
   Style reference: `docs/templates/eval-run-style-reference/pr-evaluation.md`
 
@@ -232,3 +233,4 @@ The eval execution branch (`feature/prd-82-taze-evaluation-run-14`) **never has 
 | 2026-05-03 | Apply schema type fix (TAZE-RUN1-1) in pre-run, not as a spiny-orb issue | The agent inferred correct types; the schema YAML was authored incorrectly. Fix the schema before run-14 so SCH-003 doesn't recur and CDQ-006 is the clean primary variable. |
 | 2026-05-03 | Apply IS RES-001 fix (service.instance.id) in pre-run | One-line SDK bootstrap fix; no instrumentation impact; makes IS score more meaningful for run-14 comparison. |
 | 2026-05-03 | Create evaluation/taze/run-log.md in this PRD's milestone 2 | First Type D taze PRD — the file does not yet exist. Use commit-story-v2/run-log.md column format. |
+| 2026-05-06 | 698 live-check validation must be verified as part of every eval run | spiny-orb PR #795 (698) shipped real Weaver compliance scoring into every `spiny-orb instrument` run. Before 698, live-check was a no-op. After 698, runs produce a three-state result (pass/advisory/fail) with Weaver compliance detail in the PR summary and verbose log. Pre-run verification now includes a 698 live-check gate (step 10); Findings Discussion now includes the live-check result (item 6); PR artifact evaluation now includes a live-check section. Same changes applied to PRDs #86 and #88 and the Type D template in `docs/language-extension-plan.md`. |

--- a/prds/86-evaluation-run-16.md
+++ b/prds/86-evaluation-run-16.md
@@ -113,6 +113,7 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
   1. **Handoff triage review**: Read the spiny-orb team's triage of `evaluation/commit-story-v2/run-15/actionable-fix-output.md`. Check which findings were filed as issues.
   2. **Outer catch guidance fix** (P1 — critical, RUN15-1): Verify the fix for the outer catch gap in `summary-detector.js` landed. The fix involves prompt guidance distinguishing inner graceful-degradation catches (NDS-007 applies — no error recording) from the outer span-level catch (still needed for unexpected exceptions). Confirm the relevant issue/PR is closed and merged to spiny-orb main.
   3. **Other spiny-orb fixes since run-15**: Check spiny-orb main for any merged PRs relevant to commit-story-v2 evaluation (push detection bug RUN15-3, advisory quality improvements #728 #729).
+  3a. **698 live-check gate**: Confirm the 698 live-check feature is on spiny-orb main. Run `git -C ~/Documents/Repositories/spinybacked-orbweaver log --oneline | head -20 | grep -i 'prd-698\|live-check'`. If present, the run will produce a three-state live-check result (pass/advisory/fail) in the PR summary and verbose log — the Findings Discussion live-check item and PR artifact live-check section both apply. If absent, note in lessons-for-prd17.md and skip those items.
   4. **Target repo readiness** (commit-story-v2): Verify on `main`, clean working tree, spiny-orb.yaml and semconv/ exist. **Before switching to main, check for uncommitted artifacts on the current instrument branch** (run `git status` in commit-story-v2) and commit any to that branch before switching.
   5. **Push auth stability check**: Verify token still works (dry-run push to non-existent branch).
   6. **File inventory**: Count .js files in commit-story-v2's `src/` directory.
@@ -129,7 +130,7 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
 
   **After saving artifacts and committing, push the eval branch to origin immediately** (`git push -u origin <eval-branch>`). The branch holds the only copy of run-16 artifacts until the "Copy artifacts to main" milestone runs — do not leave it local-only.
 
-- [ ] **Findings Discussion** *(user-facing checkpoint 1)* — After `run-summary.md` is written, before any evaluation documents are started: report to Whitney: (1) files committed / failed / partial, (2) whether any checkpoint failures occurred, (3) COV-003 result for `summary-detector.js` — specifically whether `getDaysWithEntries` and `getDaysWithDailySummaries` now have outer catches consistent with `findUnsummarized*`, (4) `journal-graph.js` attempt count (did the 1-attempt result hold?), (5) quality score if visible, (6) cost, (7) push/PR status. Keep it conversational, under 10 lines. Wait for acknowledgment before proceeding.
+- [ ] **Findings Discussion** *(user-facing checkpoint 1)* — After `run-summary.md` is written, before any evaluation documents are started: report to Whitney: (1) files committed / failed / partial, (2) whether any checkpoint failures occurred, (3) COV-003 result for `summary-detector.js` — specifically whether `getDaysWithEntries` and `getDaysWithDailySummaries` now have outer catches consistent with `findUnsummarized*`, (4) `journal-graph.js` attempt count (did the 1-attempt result hold?), (5) quality score if visible, (6) cost, (7) push/PR status, (8) live-check result — pass/advisory/fail plus a one-line summary of what Weaver found (or "not triggered" if 698 was absent from the build). Keep it conversational, under 10 lines. Wait for acknowledgment before proceeding.
 
 - [ ] **Failure deep-dives** — For each failed file AND run-level failure. Includes any partial files.
   Produces: `evaluation/commit-story-v2/run-16/failure-deep-dives.md`
@@ -139,7 +140,7 @@ The **evaluation execution branch** created by `/prd-start` from main **never me
   Produces: `evaluation/commit-story-v2/run-16/per-file-evaluation.md`
   Style reference: `Read docs/templates/eval-run-style-reference/per-file-evaluation.md`
 
-- [ ] **PR artifact evaluation** — Evaluate PR quality.
+- [ ] **PR artifact evaluation** — Evaluate PR quality. Include a live-check section: assess the three-state result (pass/advisory/fail), whether Weaver's compliance findings accurately reflect the telemetry produced, and whether the advisory detail is actionable. If 698 was absent from the build, note that and skip the live-check section.
   Produces: `evaluation/commit-story-v2/run-16/pr-evaluation.md`
   Style reference: `Read docs/templates/eval-run-style-reference/pr-evaluation.md`
 

--- a/prds/88-evaluation-run-4-release-it.md
+++ b/prds/88-evaluation-run-4-release-it.md
@@ -123,6 +123,7 @@ The feature branch for this PRD (`feature/prd-88-evaluation-run-4-release-it`) *
   7. **File inventory**: Confirm 23 `.js` files in `lib/` — run `find lib -name "*.js" | wc -l` from `~/Documents/Repositories/release-it/`.
   8. **Rebuild spiny-orb**: Rebuild from **main** (unless a specific fix branch has been communicated for this run). Record SHA.
   9. **Record versions**: Node.js version, spiny-orb version/SHA, release-it version.
+  10. **698 live-check gate**: Confirm the 698 live-check feature is on spiny-orb main. Run `git -C ~/Documents/Repositories/spinybacked-orbweaver log --oneline | head -20 | grep -i 'prd-698\|live-check'`. If present, the run will produce a three-state live-check result (pass/advisory/fail) in the PR summary and verbose log — the Findings Discussion live-check item and PR artifact live-check section both apply. If absent, note in lessons-for-run5.md and skip those items.
   10. Append observations to `evaluation/release-it/run-4/lessons-for-run5.md`.
 
   **If RUN3-1 is not fixed**: proceed anyway. Document the miss. Q×F will remain near 3.0 but run-4 still produces valid evaluation data.
@@ -142,7 +143,7 @@ The feature branch for this PRD (`feature/prd-88-evaluation-run-4-release-it`) *
 
 - [ ] **Findings Discussion** *(user-facing checkpoint 1)*
 
-  After `run-summary.md` is written, before any evaluation documents: report to Whitney with a raw overview — files committed/failed/partial, quality score if visible in log, cost, push/PR status, top 1-2 surprises. Conversational, under 10 lines. Wait for acknowledgment before proceeding.
+  After `run-summary.md` is written, before any evaluation documents: report to Whitney with a raw overview — files committed/failed/partial, quality score if visible in log, cost, push/PR status, live-check result (pass/advisory/fail plus a one-line summary of what Weaver found, or "not triggered" if 698 was absent from the build), top 1-2 surprises. Conversational, under 10 lines. Wait for acknowledgment before proceeding.
 
   Success criteria: Whitney has acknowledged the findings overview.
 
@@ -160,6 +161,7 @@ The feature branch for this PRD (`feature/prd-88-evaluation-run-4-release-it`) *
 
 - [ ] **PR artifact evaluation**
 
+  Include a live-check section: assess the three-state result (pass/advisory/fail), whether Weaver's compliance findings accurately reflect the telemetry produced, and whether the advisory detail is actionable. If 698 was absent from the build, note that and skip the live-check section.
   Produces: `evaluation/release-it/run-4/pr-evaluation.md`
   Style reference: `Read docs/templates/eval-run-style-reference/pr-evaluation.md`
 


### PR DESCRIPTION
## Summary

- Adds a 698 live-check gate step to the pre-run verification milestone in PRDs #82, #86, and #88
- Adds live-check result (pass/advisory/fail) as a required Findings Discussion item in all three PRDs
- Adds a live-check summary evaluation section to the PR artifact evaluation milestone in all three PRDs
- Updates the Type D recurring run template in `docs/language-extension-plan.md` with the same three additions as standing requirements

spiny-orb PR #795 (698) shipped real Weaver compliance scoring into every `spiny-orb instrument` run. Before 698, live-check was a no-op. These updates ensure future eval runs capture and evaluate that new signal.

## Test plan
- [ ] Docs-only — no code changes
- [ ] Update PROGRESS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation run procedures with new checkpoints for findings discussion and handoff moments
  * Added live-check gate verification requirements across multiple evaluation runs
  * Enhanced artifact handling and reporting guidelines for structured findings discussions
  * Expanded evaluation workflow with formalized pre-run and post-run step guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->